### PR TITLE
Support Jdk 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ logs/
 .settings/
 .project
 .classpath
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
 			<version>2.11.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -119,7 +124,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.5.0</version>
 				<executions>
 					<execution>
 						<id>xjc-schema1</id>


### PR DESCRIPTION
Fix  #18 

* [X] Bumping `jaxb2-maven-plugin` version to the latest `2.5.0`  
* [X] Adding `jaxb-api` as it got removed in JDK 11  

Misc :  
* [X] Add .idea / .iml to `.gitignore` for people using IntelliJ
