### PR TITLE
Revising suggesters block following new spec for Lunatic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.5</version>
+	<version>2.2.6</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -149,23 +149,13 @@
         <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
 
-
-	<xs:complexType name="SuggesterType">
-    	<xs:all>
-    		<xs:element name="L_DEPNAIS" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="L_PAYSNAIS" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="L_NATIONETR" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="cog-communes" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="bailleurs-sociaux" type="SuggesterOccurence" minOccurs="0"/>
-    	</xs:all>
-    </xs:complexType>
     
-    <xs:complexType name="SuggesterOccurence">
+    <xs:complexType name="SuggesterType">
     	<xs:sequence>
+    	    <xs:element name="name" type="xs:string"/>
     		<xs:element name="fields" type="SuggesterField" minOccurs="1" maxOccurs="unbounded"/>
     		<xs:element name="max" type="xs:integer" minOccurs="0"/>
     		<xs:element name="order" type="SuggesterOrder" minOccurs="0"/>
-    		<xs:element name="name" type="xs:string"/>
     		<xs:element name="queryParser" type="SuggesterQueryParser"/>
     		<xs:element name="url" type="xs:string" minOccurs="0"/>
     		<xs:element name="version" type="xs:string"/>

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -146,21 +146,11 @@
     </xs:complexType>
     
     <xs:complexType name="SuggesterType">
-    	<xs:all>
-    		<xs:element name="L_DEPNAIS" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="L_PAYSNAIS" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="L_NATIONETR" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="cog-communes" type="SuggesterOccurence" minOccurs="0"/>
-    		<xs:element name="bailleurs-sociaux" type="SuggesterOccurence" minOccurs="0"/>
-    	</xs:all>
-    </xs:complexType>
-    
-    <xs:complexType name="SuggesterOccurence">
     	<xs:sequence>
+    		<xs:element name="name" type="xs:string"/>
     		<xs:element name="fields" type="SuggesterField" minOccurs="1" maxOccurs="unbounded"/>
     		<xs:element name="max" type="xs:integer" minOccurs="0"/>
     		<xs:element name="order" type="SuggesterOrder" minOccurs="0"/>
-    		<xs:element name="name" type="xs:string"/>
     		<xs:element name="queryParser" type="SuggesterQueryParser"/>
     		<xs:element name="url" type="xs:string" minOccurs="0"/>
     		<xs:element name="version" type="xs:string"/>


### PR DESCRIPTION
LunaticModel and LunaticModelFlat xsd have been modified to fit with the new suggesters block needed for Lunatic
Version is bumped to 2.2.6