### PR TITLE
Workaround for suggesters and rules tag of field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.7</version>
+	<version>2.2.8</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -166,7 +166,10 @@
     <xs:complexType name="SuggesterField">
     	<xs:sequence>
     		<xs:element name="name" type="xs:string"/>
-    		<xs:element name="rules" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    		<xs:choice>
+				<xs:element name="rules" type="xs:string"/>
+				<xs:element name="rulesA" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+			</xs:choice>
     		<xs:element name="language" type="xs:string" minOccurs="0"/>
     		<xs:element name="min" type="xs:integer" minOccurs="0"/>
     		<xs:element name="stemmer" type="xs:boolean" minOccurs="0"/>

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -161,8 +161,11 @@
     <xs:complexType name="SuggesterField">
     	<xs:sequence>
     		<xs:element name="name" type="xs:string"/>
-    		<xs:element name="rules" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-    		<xs:element name="language" type="xs:string" minOccurs="0"/>
+			<xs:choice>
+				<xs:element name="rules" type="xs:string"/>
+				<xs:element name="rulesA" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+			</xs:choice>
+			<xs:element name="language" type="xs:string" minOccurs="0"/>
     		<xs:element name="min" type="xs:integer" minOccurs="0"/>
     		<xs:element name="stemmer" type="xs:boolean" minOccurs="0"/>
     		<xs:element name="synonyms" type="FieldSynonym" minOccurs="0" maxOccurs="unbounded"/>

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -30,7 +30,7 @@
     <xsl:template match="*[local-name(.)='map'][parent::*[@key='value' and local-name(.)='array'] or (self::*[@key='value'] and preceding-sibling::*[@key='variableType'])]" mode="clean">
         <xsl:apply-templates mode="clean"/>
     </xsl:template>
-    <!-- delete key attribue for array inside array -->
+    <!-- delete key attribute for array inside array -->
     <xsl:template match="*[local-name(.)='array' and @key=('PREVIOUS','COLLECTED','FORCED','EDITED','INPUTED','value')][ancestor::*[local-name(.)='array' and @key=('PREVIOUS','COLLECTED','FORCED','EDITED','INPUTED','value')]]" mode="clean">
         <xsl:copy>
             <xsl:apply-templates mode="clean"/>
@@ -47,6 +47,14 @@
                     <xsl:apply-templates mode="clean"/>
                 </xsl:copy>
             </xsl:for-each>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- rename the rulesA key of suggesters to rules -->
+    <xsl:template match="*[@key='rulesA']" mode="clean">
+        <xsl:copy>
+        	<xsl:attribute name="key" select="'rules'"/>
+            <xsl:apply-templates select="node()" mode="clean"/>
         </xsl:copy>
     </xsl:template>
     


### PR DESCRIPTION
Workaround for suggesters : the tag for field rules can be 'rules' if soft or 'rulesA' if array, then it is changed in json-cleaner.xsl step

Lunatic-model version is bumped to 2.2.8