### PR TITLE
Dev lunatic cleaning block and label object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.10</version>
+	<version>2.2.11</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -30,6 +30,7 @@
                     <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="suggesters" type="SuggesterType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="variables" type="IVariableType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="cleaning" type="CleaningType" minOccurs="0" maxOccurs="1"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -530,5 +531,11 @@
             <xs:enumeration value="ERROR"/>
         </xs:restriction>
     </xs:simpleType>
+    
+    <xs:complexType name="CleaningType">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:any processContents="lax"/>
+        </xs:sequence>
+    </xs:complexType>
 
 </xs:schema>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -60,7 +60,7 @@
     <xs:complexType name="Options">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -71,9 +71,9 @@
                     <xs:element name="loopDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="lines" type="LinesLoop" minOccurs="0"/>
                     <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="iterations" type="labelType" minOccurs="0"/>
                 </xs:sequence>
                 <xs:attribute name="maxPage" type="xs:string"/>
-                <xs:attribute name="iterations" type="xs:string"/>
                 <xs:attribute name="depth" type="xs:integer"/>
                 <xs:attribute name="paginatedLoop" type="xs:boolean"/>
             </xs:extension>
@@ -81,20 +81,23 @@
     </xs:complexType>
 
     <xs:complexType name="LinesLoop">
-        <xs:attribute name="min" type="xs:string" use="required"/>
-        <xs:attribute name="max" type="xs:string" use="required"/>
+    	<xs:sequence>
+        	<xs:element name="min" type="labelType"/>
+        	<xs:element name="max" type="labelType"/>
+        </xs:sequence>
     </xs:complexType>
-
+    
     <xs:complexType name="ConditionFilterType">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
+            <xs:element name="type" type="xs:string"/>
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="ComponentType" abstract="true">
         <xs:sequence>
-            <xs:element name="label" type="label" minOccurs="0"/>
+            <xs:element name="label" type="labelType" minOccurs="0"/>
             <xs:element name="declarations" type="DeclarationType" minOccurs="0" maxOccurs="unbounded"/>
             <!-- Warning : To validate the name -->
             <xs:element name="conditionFilter" type="ConditionFilterType" minOccurs="0"/>
@@ -111,7 +114,7 @@
         <xs:attribute name="page" type="xs:string"/>
     </xs:complexType>
 
-    <xs:complexType name="label">
+    <xs:complexType name="labelType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0"/>
             <xs:element name="type" type="xs:string" minOccurs="0"/>
@@ -127,7 +130,7 @@
 
     <xs:complexType name="sequenceDescription">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="page" type="xs:string"/>
@@ -461,7 +464,7 @@
     <xs:complexType name="CellsType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="label" type="label" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="label" type="labelType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dateFormat" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -481,13 +484,15 @@
     </xs:complexType>
 
     <xs:complexType name="LinesRoster">
-        <xs:attribute name="min" type="xs:integer" use="required"/>
-        <xs:attribute name="max" type="xs:integer" use="required"/>
+		<xs:sequence>
+	        <xs:element name="min" type="labelType"/>
+	        <xs:element name="max" type="labelType"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="ResponsesCheckboxGroup">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
             <xs:element name="response" type="ResponseType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
@@ -495,7 +500,7 @@
 
     <xs:complexType name="DeclarationType">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
         <xs:attribute name="declarationType" type="DeclarationTypeEnum"/>
@@ -524,8 +529,8 @@
 
     <xs:complexType name="ControlType">
         <xs:sequence>
-            <xs:element name="control" type="xs:string"/>
-            <xs:element name="errorMessage" type="xs:string"/>
+            <xs:element name="control" type="labelType"/>
+            <xs:element name="errorMessage" type="labelType"/>
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" />

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -60,7 +60,7 @@
     <xs:complexType name="Options">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -94,7 +94,7 @@
 
     <xs:complexType name="ComponentType" abstract="true">
         <xs:sequence>
-            <xs:element name="label" type="xs:string" minOccurs="0"/>
+            <xs:element name="label" type="label" minOccurs="0"/>
             <xs:element name="declarations" type="DeclarationType" minOccurs="0" maxOccurs="unbounded"/>
             <!-- Warning : To validate the name -->
             <xs:element name="conditionFilter" type="ConditionFilterType" minOccurs="0"/>
@@ -111,6 +111,13 @@
         <xs:attribute name="page" type="xs:string"/>
     </xs:complexType>
 
+    <xs:complexType name="label">
+        <xs:sequence>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+            <xs:element name="type" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    
     <xs:complexType name="hierarchy">
         <xs:sequence>
             <xs:element name="sequence" type="sequenceDescription" minOccurs="0"/>
@@ -120,7 +127,7 @@
 
     <xs:complexType name="sequenceDescription">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="page" type="xs:string"/>
@@ -454,7 +461,7 @@
     <xs:complexType name="CellsType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="label" type="label" minOccurs="0" maxOccurs="1"/>
             <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dateFormat" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -480,7 +487,7 @@
 
     <xs:complexType name="ResponsesCheckboxGroup">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
             <xs:element name="response" type="ResponseType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
@@ -488,7 +495,7 @@
 
     <xs:complexType name="DeclarationType">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
         <xs:attribute name="declarationType" type="DeclarationTypeEnum"/>

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -53,7 +53,7 @@
     <xs:complexType name="Options">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -64,9 +64,9 @@
                     <xs:element name="loopDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="lines" type="LinesLoop" minOccurs="0"/>
                     <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="iterations" type="labelType" minOccurs="0"/>
                 </xs:sequence>
                 <xs:attribute name="maxPage" type="xs:string"/>
-                <xs:attribute name="iterations" type="xs:string"/>
                 <xs:attribute name="depth" type="xs:integer"/>
                 <xs:attribute name="paginatedLoop" type="xs:boolean"/>
             </xs:extension>
@@ -74,20 +74,23 @@
     </xs:complexType>
 
     <xs:complexType name="LinesLoop">
-        <xs:attribute name="min" type="xs:string" use="required"/>
-        <xs:attribute name="max" type="xs:string" use="required"/>
+    	<xs:sequence>
+        	<xs:element name="min" type="labelType"/>
+        	<xs:element name="max" type="labelType"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="ConditionFilterType">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
+            <xs:element name="type" type="xs:string"/>
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="ComponentType" abstract="true">
         <xs:sequence>
-            <xs:element name="label" type="label" minOccurs="0"/>
+            <xs:element name="label" type="labelType" minOccurs="0"/>
             <xs:element name="declarations" type="DeclarationType" minOccurs="0" maxOccurs="unbounded"/>
             <!-- Warning : To validate the name -->
             <xs:element name="conditionFilter" type="ConditionFilterType" minOccurs="0"/>
@@ -106,7 +109,7 @@
         <xs:attribute name="page" type="xs:string"/>
     </xs:complexType>
     
-    <xs:complexType name="label">
+    <xs:complexType name="labelType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0"/>
             <xs:element name="type" type="xs:string" minOccurs="0"/>
@@ -122,7 +125,7 @@
 
     <xs:complexType name="sequenceDescription">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="page" type="xs:string"/>
@@ -456,7 +459,7 @@
     <xs:complexType name="CellsType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="label" type="label" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="label" type="labelType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dateFormat" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -476,13 +479,15 @@
     </xs:complexType>
 
     <xs:complexType name="LinesRoster">
-        <xs:attribute name="min" type="xs:integer" use="required"/>
-        <xs:attribute name="max" type="xs:integer" use="required"/>
+    	<xs:sequence>
+        	<xs:element name="min" type="labelType"/>
+        	<xs:element name="max" type="labelType"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="ResponsesCheckboxGroup">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
             <xs:element name="response" type="ResponseType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
@@ -490,7 +495,7 @@
 
     <xs:complexType name="DeclarationType">
         <xs:sequence>
-            <xs:element name="label" type="label"/>
+            <xs:element name="label" type="labelType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
         <xs:attribute name="declarationType" type="DeclarationTypeEnum"/>
@@ -519,8 +524,8 @@
 
     <xs:complexType name="ControlType">
         <xs:sequence>
-            <xs:element name="control" type="xs:string"/>
-            <xs:element name="errorMessage" type="xs:string"/>
+            <xs:element name="control" type="labelType"/>
+            <xs:element name="errorMessage" type="labelType"/>
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" />

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -30,6 +30,7 @@
                     <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="suggesters" type="SuggesterType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="variables" type="IVariableType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="cleaning" type="CleaningType" minOccurs="0" maxOccurs="1"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -525,5 +526,18 @@
             <xs:enumeration value="ERROR"/>
         </xs:restriction>
     </xs:simpleType>
+    
+    <xs:complexType name="CleaningType">
+      <xs:sequence>
+        <xs:element name="cleaning">
+          <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+              <xs:any processContents="lax"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    
 
 </xs:schema>

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -528,15 +528,9 @@
     </xs:simpleType>
     
     <xs:complexType name="CleaningType">
-      <xs:sequence>
-        <xs:element name="cleaning">
-          <xs:complexType>
-            <xs:sequence maxOccurs="unbounded">
-              <xs:any processContents="lax"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-      </xs:sequence>
+        <xs:sequence maxOccurs="unbounded">
+            <xs:any processContents="lax"/>
+        </xs:sequence>
     </xs:complexType>
     
 

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -53,7 +53,7 @@
     <xs:complexType name="Options">
         <xs:sequence>
             <xs:element name="value" type="xs:string"/>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -87,7 +87,7 @@
 
     <xs:complexType name="ComponentType" abstract="true">
         <xs:sequence>
-            <xs:element name="label" type="xs:string" minOccurs="0"/>
+            <xs:element name="label" type="label" minOccurs="0"/>
             <xs:element name="declarations" type="DeclarationType" minOccurs="0" maxOccurs="unbounded"/>
             <!-- Warning : To validate the name -->
             <xs:element name="conditionFilter" type="ConditionFilterType" minOccurs="0"/>
@@ -105,6 +105,13 @@
         <xs:attribute name="mandatory" type="xs:boolean"/>
         <xs:attribute name="page" type="xs:string"/>
     </xs:complexType>
+    
+    <xs:complexType name="label">
+        <xs:sequence>
+            <xs:element name="value" type="xs:string" minOccurs="0"/>
+            <xs:element name="type" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:complexType name="hierarchy">
         <xs:sequence>
@@ -115,7 +122,7 @@
 
     <xs:complexType name="sequenceDescription">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="page" type="xs:string"/>
@@ -449,7 +456,7 @@
     <xs:complexType name="CellsType">
         <xs:sequence>
             <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="label" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="label" type="label" minOccurs="0" maxOccurs="1"/>
             <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dateFormat" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -475,7 +482,7 @@
 
     <xs:complexType name="ResponsesCheckboxGroup">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
             <xs:element name="response" type="ResponseType"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
@@ -483,7 +490,7 @@
 
     <xs:complexType name="DeclarationType">
         <xs:sequence>
-            <xs:element name="label" type="xs:string"/>
+            <xs:element name="label" type="label"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" use="required"/>
         <xs:attribute name="declarationType" type="DeclarationTypeEnum"/>

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -22,7 +22,7 @@
     </xsl:template>
     
     <!-- delete type attribute except when key is linked to the suggesters block or to a label...-->
-    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')] or parent::*[@key=('label')])]" mode="clean"/>
+    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')] or parent::*[@key=('label','min','max','iterations','conditionFilter')])]" mode="clean"/>
     <!-- delete map useless inside array -->
     <xsl:template match="*[local-name(.)='map'][parent::*[@key=('PREVIOUS','COLLECTED','FORCED','EDITED','INPUTED') and local-name(.)='array'] | parent::*[@key=('values')]]" mode="clean">
         <xsl:apply-templates mode="clean"/>

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -21,8 +21,8 @@
         <xsl:copy-of select="xml-to-json($output-xml, map{'indent':true()})"/>
     </xsl:template>
     
-    <!-- delete type attribute except when key is linked to the suggesters block-->
-    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')])]" mode="clean"/>
+    <!-- delete type attribute except when key is linked to the suggesters block or to a label...-->
+    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')] or parent::*[@key=('label')])]" mode="clean"/>
     <!-- delete map useless inside array -->
     <xsl:template match="*[local-name(.)='map'][parent::*[@key=('PREVIOUS','COLLECTED','FORCED','EDITED','INPUTED') and local-name(.)='array'] | parent::*[@key=('values')]]" mode="clean">
         <xsl:apply-templates mode="clean"/>

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -58,6 +58,22 @@
         </xsl:copy>
     </xsl:template>
     
+    <!-- Transform the array produced inside cleaning block into simple map object -->
+    <!-- 1. When encountering the array ndoe, not copying it but treating its children -->
+    <xsl:template match="*[parent::*/@key='cleaning']" mode="clean">
+        <xsl:apply-templates select="node()" mode="clean"/>
+    </xsl:template>
+    <!-- 2. When encountering the map child of the array, putting the attribute key of variable inside -->
+    <xsl:template match="*[parent::*/parent::*/@key='cleaning']" mode="clean">
+        <xsl:copy>
+            <xsl:attribute name="key" select="parent::*/@key"/>
+            <xsl:apply-templates select="node()" mode="clean"/>
+        </xsl:copy>
+    </xsl:template>
+    <!-- 3. When encountering value node, do not copy (it is a line return wrongly treated as an object 
+    since we do not have a proper schema model for the cleaning part...-->
+    <xsl:template match="*[@key='value' and ancestor::*/@key='cleaning']"  mode="clean"/>
+    
     <xsl:template match="@*|node()" mode="clean">
         <xsl:choose>
             <xsl:when test="self::text()">

--- a/src/test/resources/dummy/form.xml
+++ b/src/test/resources/dummy/form.xml
@@ -28,6 +28,7 @@
       </declarations>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -49,6 +50,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -80,6 +82,7 @@
          </declarations>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -103,6 +106,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -123,6 +127,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -151,6 +156,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -184,6 +190,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -224,6 +231,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -264,6 +272,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -305,6 +314,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -339,6 +349,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -373,6 +384,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -407,6 +419,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -441,6 +454,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -475,6 +489,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -515,6 +530,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -544,6 +560,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -597,6 +614,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -649,6 +667,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -764,6 +783,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -792,6 +812,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -855,6 +876,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -990,6 +1012,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -1125,6 +1148,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -1392,6 +1416,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1412,6 +1437,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -1440,6 +1466,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -1647,6 +1674,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -1990,6 +2018,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -2018,6 +2047,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -2254,6 +2284,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -2290,6 +2321,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -2519,6 +2551,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2541,6 +2574,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -2584,7 +2618,16 @@
          <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
          <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
          <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
-         <lines min="1" max="10"/>
+         <lines>
+            <min>
+               <value>1</value>
+               <type>VTL|MD</type>
+            </min>
+            <max>
+               <value>10</value>
+               <type>VTL|MD</type>
+            </max>
+         </lines>
          <cells type="header">
             <cells headerCell="true">
                <label>
@@ -3008,6 +3051,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3171,6 +3215,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3398,6 +3443,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3422,6 +3468,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3446,6 +3493,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3469,6 +3517,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -3497,6 +3546,7 @@
                </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+                  <type>VTL|MD</type>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
@@ -3530,6 +3580,7 @@
                </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+                  <type>VTL|MD</type>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
@@ -3556,12 +3607,16 @@
                componentType="Loop"
                id="kiq7cbgo"
                depth="1"
-               iterations="count(NAME_CHAR)"
                page="35"
                maxPage="3"
                paginatedLoop="true">
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -3579,6 +3634,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3601,6 +3657,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -3641,6 +3698,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -3667,6 +3725,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
@@ -3688,6 +3747,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6z12s2d" page="36">

--- a/src/test/resources/dummy/form.xml
+++ b/src/test/resources/dummy/form.xml
@@ -3610,10 +3610,6 @@
                page="35"
                maxPage="3"
                paginatedLoop="true">
-      <iterations>
-         <value>count(NAME_CHAR)</value>
-         <type>VTL|MD</type>
-      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <type>VTL|MD</type>
@@ -3714,6 +3710,10 @@
             <response name="MEMORY_CHAR"/>
          </components>
       </components>
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
    </components>
    <components xsi:type="Sequence"
                componentType="Sequence"

--- a/src/test/resources/dummy/form.xml
+++ b/src/test/resources/dummy/form.xml
@@ -6,23 +6,35 @@
                enoCoreVersion="2.2.8"
                pagination="question"
                maxPage="37">
-   <label>Questionnaire SIMPSONS 20201215</label>
+   <label>
+      <value>Questionnaire SIMPSONS 20201215</value>
+      <type>VTL|MD</type>
+   </label>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6p0ti5h"
                page="1">
-      <label>"I - Introduction"</label>
+      <label>
+         <value>"I - Introduction"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j6p0ti5h-d1"
                     position="AFTER_QUESTION_TEXT">
-         <label>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</label>
+         <label>
+            <value>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
-            <label>"I - Introduction"</label>
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="Textarea"
@@ -31,13 +43,19 @@
                   maxLength="500"
                   mandatory="true"
                   page="2">
-         <label>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</label>
+         <label>
+            <value>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>COMMENT</bindingDependencies>
@@ -48,18 +66,27 @@
                   id="j6p0np9q"
                   mandatory="false"
                   page="3">
-         <label>"➡ 2. If you agree to answer this questionnaire, please check the box"</label>
+         <label>
+            <value>"➡ 2. If you agree to answer this questionnaire, please check the box"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="COMMENT"
                        id="j6p0np9q-kir6xl1e"
                        position="AFTER_QUESTION_TEXT">
-            <label>"If not, this is unfortunately the end of this questionnaire."</label>
+            <label>
+               <value>"If not, this is unfortunately the end of this questionnaire."</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>READY</bindingDependencies>
@@ -70,13 +97,19 @@
                   id="j6p6my1d"
                   filterDescription="false"
                   page="3">
-         <label>"If you are not ready, please go to the end of the questionnaire"</label>
+         <label>
+            <value>"If you are not ready, please go to the end of the questionnaire"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
       </components>
@@ -84,17 +117,26 @@
                   componentType="Subsequence"
                   id="j6p0s7o5"
                   goToPage="4">
-         <label>"General knowledge of the series"</label>
+         <label>
+            <value>"General knowledge of the series"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6p0s7o5" page="4">
-               <label>"General knowledge of the series"</label>
+               <label>
+                  <value>"General knowledge of the series"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
          <components xsi:type="Input"
@@ -103,17 +145,26 @@
                      maxLength="30"
                      mandatory="false"
                      page="4">
-            <label>"➡ 3. Who is the producer?"</label>
+            <label>
+               <value>"➡ 3. Who is the producer?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>PRODUCER</bindingDependencies>
@@ -127,17 +178,26 @@
                      max="99"
                      decimals="0"
                      page="5">
-            <label>"➡ 4. What is the current season number?"</label>
+            <label>
+               <value>"➡ 4. What is the current season number?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>SEASON_NUMBER</bindingDependencies>
@@ -150,11 +210,17 @@
                      min="1900-01-01"
                      max="format-date(current-date(),'[Y0001]-[M01]-[D01]')"
                      page="6">
-            <label>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</label>
+            <label>
+               <value>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="INSTRUCTION"
                           id="kiq71eoi-kiq7dsy2"
                           position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM-DD format"</label>
+               <label>
+                  <value>"Please answer with YYYY-MM-DD format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -162,10 +228,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEFIRST</bindingDependencies>
@@ -178,11 +250,17 @@
                      mandatory="false"
                      min="1980-05"
                      page="7">
-            <label>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</label>
+            <label>
+               <value>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="COMMENT"
                           id="k5nvty2o-k5nvxld8"
                           position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM format"</label>
+               <label>
+                  <value>"Please answer with YYYY-MM format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -190,10 +268,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEYYYYMM</bindingDependencies>
@@ -207,11 +291,17 @@
                      min="1900"
                      max="year-from-date(current-date())"
                      page="8">
-            <label>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</label>
+            <label>
+               <value>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="COMMENT"
                           id="k5nw1fir-k5nvmx3n"
                           position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY format"</label>
+               <label>
+                  <value>"Please answer with YYYY format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -219,10 +309,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEYYYY</bindingDependencies>
@@ -237,17 +333,26 @@
                      max="70.00"
                      decimals="2"
                      page="9">
-            <label>"➡ 8. How long does an episode last?"</label>
+            <label>
+               <value>"➡ 8. How long does an episode last?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONH</bindingDependencies>
@@ -262,17 +367,26 @@
                      max="366.0"
                      decimals="1"
                      page="10">
-            <label>"➡ 9. How long does it take to write a new episode?"</label>
+            <label>
+               <value>"➡ 9. How long does it take to write a new episode?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIOND</bindingDependencies>
@@ -287,17 +401,26 @@
                      max="12"
                      decimals="0"
                      page="11">
-            <label>"➡ 10. How long will it take you to watch all the existing episodes?"</label>
+            <label>
+               <value>"➡ 10. How long will it take you to watch all the existing episodes?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONM</bindingDependencies>
@@ -312,17 +435,26 @@
                      max="100"
                      decimals="0"
                      page="12">
-            <label>"➡ 11. For how long have you known the Simpsons family?"</label>
+            <label>
+               <value>"➡ 11. For how long have you known the Simpsons family?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONY</bindingDependencies>
@@ -337,17 +469,26 @@
                      max="99.0"
                      decimals="1"
                      page="13">
-            <label>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</label>
+            <label>
+               <value>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>AUDIENCE_SHARE</bindingDependencies>
@@ -360,11 +501,17 @@
                componentType="Sequence"
                id="j3341528"
                page="14">
-      <label>"II - Simpsons’ city"</label>
+      <label>
+         <value>"II - Simpsons’ city"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j3341528-d2"
                     position="AFTER_QUESTION_TEXT">
-         <label>"This module asks about your general knowledge of the Simpsons city"</label>
+         <label>
+            <value>"This module asks about your general knowledge of the Simpsons city"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -372,7 +519,10 @@
       </conditionFilter>
       <hierarchy>
          <sequence id="j3341528" page="14">
-            <label>"II - Simpsons’ city"</label>
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="Radio"
@@ -380,11 +530,17 @@
                   id="j3343clt"
                   mandatory="true"
                   page="15">
-         <label>"➡ 1. In which city do the Simpsons reside?"</label>
+         <label>
+            <value>"➡ 1. In which city do the Simpsons reside?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                        id="j3343clt-d3"
                        position="AFTER_QUESTION_TEXT">
-            <label>"One possible answer"</label>
+            <label>
+               <value>"One possible answer"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -392,21 +548,33 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>CITY</bindingDependencies>
          <options>
             <value>00001</value>
-            <label>"Springfield"</label>
+            <label>
+               <value>"Springfield"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>00002</value>
-            <label>"Shelbyville"</label>
+            <label>
+               <value>"Shelbyville"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>03</value>
-            <label>"Seinfeld"</label>
+            <label>
+               <value>"Seinfeld"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="CITY"/>
       </components>
@@ -415,11 +583,17 @@
                   id="j6qdfhvw"
                   mandatory="false"
                   page="16">
-         <label>"➡ 2. Who is the Simpsons city mayor?"</label>
+         <label>
+            <value>"➡ 2. Who is the Simpsons city mayor?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                        id="j6qdfhvw-d4"
                        position="AFTER_QUESTION_TEXT">
-            <label>"Only one possible answer"</label>
+            <label>
+               <value>"Only one possible answer"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -427,25 +601,40 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>MAYOR</bindingDependencies>
          <options>
             <value>1</value>
-            <label>"Constance Harm"</label>
+            <label>
+               <value>"Constance Harm"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>2</value>
-            <label>"Timothy Lovejoy"</label>
+            <label>
+               <value>"Timothy Lovejoy"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>3</value>
-            <label>"Joe Quimby"</label>
+            <label>
+               <value>"Joe Quimby"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>OT</value>
-            <label>"Other name"</label>
+            <label>
+               <value>"Other name"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="MAYOR"/>
       </components>
@@ -454,68 +643,113 @@
                   id="j4nw5cqz"
                   mandatory="false"
                   page="17">
-         <label>"➡ 3. In which state do The Simpsons reside?"</label>
+         <label>
+            <value>"➡ 3. In which state do The Simpsons reside?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>STATE</bindingDependencies>
          <options>
             <value>1</value>
-            <label>"Washington"</label>
+            <label>
+               <value>"Washington"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>2</value>
-            <label>"Kentucky"</label>
+            <label>
+               <value>"Kentucky"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>3</value>
-            <label>"Ohio"</label>
+            <label>
+               <value>"Ohio"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>4</value>
-            <label>"Maine"</label>
+            <label>
+               <value>"Maine"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>5</value>
-            <label>"North Dakota"</label>
+            <label>
+               <value>"North Dakota"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>6</value>
-            <label>"Florida"</label>
+            <label>
+               <value>"Florida"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>7</value>
-            <label>"North Takoma"</label>
+            <label>
+               <value>"North Takoma"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>8</value>
-            <label>"California"</label>
+            <label>
+               <value>"California"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>9</value>
-            <label>"Texas"</label>
+            <label>
+               <value>"Texas"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>10</value>
-            <label>"Massachusetts"</label>
+            <label>
+               <value>"Massachusetts"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>11</value>
-            <label>"Nevada"</label>
+            <label>
+               <value>"Nevada"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>12</value>
-            <label>"Illinois"</label>
+            <label>
+               <value>"Illinois"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>13</value>
-            <label>"Not in any state, you fool!"</label>
+            <label>
+               <value>"Not in any state, you fool!"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="STATE"/>
       </components>
@@ -524,25 +758,37 @@
                componentType="Sequence"
                id="j6qe0h9q"
                page="18">
-      <label>"III - Characters"</label>
+      <label>
+         <value>"III - Characters"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qe0h9q" page="18">
-            <label>"III - Characters"</label>
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="CheckboxGroup"
                   componentType="CheckboxGroup"
                   id="j334akov"
                   page="19">
-         <label>"➡ 1. What are the pet names that the Simpsons family had?"</label>
+         <label>
+            <value>"➡ 1. What are the pet names that the Simpsons family had?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                        id="j334akov-d5"
                        position="AFTER_QUESTION_TEXT">
-            <label>"Several possible answers"</label>
+            <label>
+               <value>"Several possible answers"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -550,7 +796,10 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>PET1</bindingDependencies>
@@ -558,19 +807,31 @@
          <bindingDependencies>PET3</bindingDependencies>
          <bindingDependencies>PET4</bindingDependencies>
          <responses id="j334akov-QOP-khokqjtw">
-            <label>"Santa’s Little Helper"</label>
+            <label>
+               <value>"Santa’s Little Helper"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET1"/>
          </responses>
          <responses id="j334akov-QOP-khokur7a">
-            <label>"Snowball I"</label>
+            <label>
+               <value>"Snowball I"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET2"/>
          </responses>
          <responses id="j334akov-QOP-khol82ux">
-            <label>"Coltrane"</label>
+            <label>
+               <value>"Coltrane"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET3"/>
          </responses>
          <responses id="j334akov-QOP-khokqee5">
-            <label>"Other name"</label>
+            <label>
+               <value>"Other name"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET4"/>
          </responses>
       </components>
@@ -580,11 +841,17 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="20">
-         <label>"➡ 2. Does Jay like the following ice cream flavours?"</label>
+         <label>
+            <value>"➡ 2. Does Jay like the following ice cream flavours?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="STATEMENT"
                        id="d12-SI"
                        position="BEFORE_QUESTION_TEXT">
-            <label>"Now we are going to know if you think that Jay is a gluton."</label>
+            <label>
+               <value>"Now we are going to know if you think that Jay is a gluton."</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -592,7 +859,10 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
@@ -602,16 +872,25 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Vanilla"</label>
+               <label>
+                  <value>"Vanilla"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5w99y" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR1"/>
                <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
@@ -620,16 +899,25 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Strawberry"</label>
+               <label>
+                  <value>"Strawberry"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5ummf" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR2"/>
                <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
@@ -638,16 +926,25 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Apple"</label>
+               <label>
+                  <value>"Apple"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5mry5" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR3"/>
                <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
@@ -656,16 +953,25 @@
          <cells type="line">
             <cells>
                <value>OT</value>
-               <label>"Other flavour"</label>
+               <label>
+                  <value>"Other flavour"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5lkr8" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR4"/>
                <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
@@ -678,14 +984,20 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="21">
-         <label>"➡ 3. Which character works in the nuclear power plant?"</label>
+         <label>
+            <value>"➡ 3. Which character works in the nuclear power plant?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
@@ -695,16 +1007,25 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Charles Montgomery Burns"</label>
+               <label>
+                  <value>"Charles Montgomery Burns"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewva8xg" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER1"/>
                <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
@@ -713,16 +1034,25 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Carl Carlson"</label>
+               <label>
+                  <value>"Carl Carlson"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewvj0ad" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER2"/>
                <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
@@ -731,16 +1061,25 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Otto Mann"</label>
+               <label>
+                  <value>"Otto Mann"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewveltm" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER3"/>
                <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
@@ -749,16 +1088,25 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Lenny Leonard"</label>
+               <label>
+                  <value>"Lenny Leonard"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewvgax4" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER4"/>
                <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
@@ -771,14 +1119,20 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="22">
-         <label>"➡ 4. In which city each character was born?"</label>
+         <label>
+            <value>"➡ 4. In which city each character was born?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
@@ -789,28 +1143,46 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Selma Bouvier"</label>
+               <label>
+                  <value>"Selma Bouvier"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvjvcs" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER1"/>
                <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
@@ -819,28 +1191,46 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Kent Brockman"</label>
+               <label>
+                  <value>"Kent Brockman"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvhoda" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER2"/>
                <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
@@ -849,28 +1239,46 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Milhouse Van Houten"</label>
+               <label>
+                  <value>"Milhouse Van Houten"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewv64s5" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER3"/>
                <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
@@ -879,28 +1287,46 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Nelson Muntz"</label>
+               <label>
+                  <value>"Nelson Muntz"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvj21j" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER4"/>
                <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
@@ -909,28 +1335,46 @@
          <cells type="line">
             <cells>
                <value>5</value>
-               <label>"Crazy Cat Lady"</label>
+               <label>
+                  <value>"Crazy Cat Lady"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewva5uf" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER5"/>
                <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
@@ -942,31 +1386,46 @@
                componentType="Sequence"
                id="j4nw88h2"
                page="23">
-      <label>"IV - General questions"</label>
+      <label>
+         <value>"IV - General questions"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j4nw88h2" page="23">
-            <label>"IV - General questions"</label>
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="Subsequence"
                   componentType="Subsequence"
                   id="j6qe237q"
                   goToPage="24">
-         <label>"Kwik-E-Mart"</label>
+         <label>
+            <value>"Kwik-E-Mart"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qe237q" page="24">
-               <label>"Kwik-E-Mart"</label>
+               <label>
+                  <value>"Kwik-E-Mart"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
          <components xsi:type="Table"
@@ -975,17 +1434,26 @@
                      positioning="HORIZONTAL"
                      mandatory="false"
                      page="24">
-            <label>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</label>
+            <label>
+               <value>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
+                  <label>
+                     <value>"Kwik-E-Mart"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>PERCENTAGE_EXPENSES11</bindingDependencies>
@@ -997,20 +1465,32 @@
             <bindingDependencies>PERCENTAGE_EXPENSES71</bindingDependencies>
             <cells type="header">
                <cells headerCell="true" colspan="2">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Percentage"</label>
+                  <label>
+                     <value>"Percentage"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells rowspan="2">
                   <value>A</value>
-                  <label>"Frozen products"</label>
+                  <label>
+                     <value>"Frozen products"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>A1</value>
-                  <label>"Ice creams"</label>
+                  <label>
+                     <value>"Ice creams"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv2h3o"
                       componentType="InputNumber"
@@ -1025,7 +1505,10 @@
             <cells type="line">
                <cells>
                   <value>A2</value>
-                  <label>"Jasper Beardly"</label>
+                  <label>
+                     <value>"Jasper Beardly"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvka2j"
                       componentType="InputNumber"
@@ -1040,11 +1523,17 @@
             <cells type="line">
                <cells rowspan="3">
                   <value>B</value>
-                  <label>"Meat"</label>
+                  <label>
+                     <value>"Meat"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>B1</value>
-                  <label>"Bacon"</label>
+                  <label>
+                     <value>"Bacon"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv1f2a"
                       componentType="InputNumber"
@@ -1059,7 +1548,10 @@
             <cells type="line">
                <cells>
                   <value>B2</value>
-                  <label>"Pork chop"</label>
+                  <label>
+                     <value>"Pork chop"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvb2ql"
                       componentType="InputNumber"
@@ -1074,7 +1566,10 @@
             <cells type="line">
                <cells>
                   <value>B3</value>
-                  <label>"Chicken"</label>
+                  <label>
+                     <value>"Chicken"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvbxla"
                       componentType="InputNumber"
@@ -1089,11 +1584,17 @@
             <cells type="line">
                <cells>
                   <value>C</value>
-                  <label>"Compote"</label>
+                  <label>
+                     <value>"Compote"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>C1</value>
-                  <label>"Powersauce"</label>
+                  <label>
+                     <value>"Powersauce"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvkjp0"
                       componentType="InputNumber"
@@ -1108,7 +1609,10 @@
             <cells type="line">
                <cells colspan="2">
                   <value>D</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv2cyx"
                       componentType="InputNumber"
@@ -1123,7 +1627,10 @@
             <cells type="line">
                <cells colspan="2">
                   <value>E</value>
-                  <label>"Total"</label>
+                  <label>
+                     <value>"Total"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="false"/>
             </cells>
@@ -1134,17 +1641,26 @@
                      positioning="HORIZONTAL"
                      mandatory="false"
                      page="25">
-            <label>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</label>
+            <label>
+               <value>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
+                  <label>
+                     <value>"Kwik-E-Mart"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
@@ -1157,33 +1673,54 @@
             <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
             <cells type="header">
                <cells headerCell="true" colspan="2">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"In his last food shopping"</label>
+                  <label>
+                     <value>"In his last food shopping"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells rowspan="2">
                   <value>A</value>
-                  <label>"Frozen products"</label>
+                  <label>
+                     <value>"Frozen products"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>A1</value>
-                  <label>"Ice creams"</label>
+                  <label>
+                     <value>"Ice creams"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6pljq" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING11"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
@@ -1192,20 +1729,32 @@
             <cells type="line">
                <cells>
                   <value>A2</value>
-                  <label>"Jasper Beardly"</label>
+                  <label>
+                     <value>"Jasper Beardly"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6mgpv" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING21"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING21</bindingDependencies>
@@ -1214,24 +1763,39 @@
             <cells type="line">
                <cells rowspan="3">
                   <value>B</value>
-                  <label>"Meat"</label>
+                  <label>
+                     <value>"Meat"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>B1</value>
-                  <label>"Bacon"</label>
+                  <label>
+                     <value>"Bacon"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6pmtz" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING31"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING31</bindingDependencies>
@@ -1240,20 +1804,32 @@
             <cells type="line">
                <cells>
                   <value>B2</value>
-                  <label>"Pork chop"</label>
+                  <label>
+                     <value>"Pork chop"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6k4lf" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING41"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING41</bindingDependencies>
@@ -1262,20 +1838,32 @@
             <cells type="line">
                <cells>
                   <value>B3</value>
-                  <label>"Chicken"</label>
+                  <label>
+                     <value>"Chicken"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6p70n" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING51"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING51</bindingDependencies>
@@ -1284,24 +1872,39 @@
             <cells type="line">
                <cells>
                   <value>C</value>
-                  <label>"Compote"</label>
+                  <label>
+                     <value>"Compote"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>C1</value>
-                  <label>"Powersauce"</label>
+                  <label>
+                     <value>"Powersauce"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6lh5v" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING61"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING61</bindingDependencies>
@@ -1310,20 +1913,32 @@
             <cells type="line">
                <cells colspan="2">
                   <value>D</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq703te" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING71"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING71</bindingDependencies>
@@ -1332,20 +1947,32 @@
             <cells type="line">
                <cells colspan="2">
                   <value>E</value>
-                  <label>"Total"</label>
+                  <label>
+                     <value>"Total"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6zpd3" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING81"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
@@ -1357,17 +1984,26 @@
                   componentType="Subsequence"
                   id="j6qejudb"
                   goToPage="26">
-         <label>"Clowning"</label>
+         <label>
+            <value>"Clowning"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qejudb" page="26">
-               <label>"Clowning"</label>
+               <label>
+                  <value>"Clowning"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
          <components xsi:type="Table"
@@ -1376,17 +2012,26 @@
                      positioning="HORIZONTAL"
                      mandatory="false"
                      page="26">
-            <label>"➡ 3. Who did these clownings and tell us what you remember?"</label>
+            <label>
+               <value>"➡ 3. Who did these clownings and tell us what you remember?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qejudb" page="26">
-                  <label>"Clowning"</label>
+                  <label>
+                     <value>"Clowning"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>CLOWNING11</bindingDependencies>
@@ -1399,36 +2044,60 @@
             <bindingDependencies>CLOWNING42</bindingDependencies>
             <cells type="header">
                <cells headerCell="true">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Clowning"</label>
+                  <label>
+                     <value>"Clowning"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Remember?"</label>
+                  <label>
+                     <value>"Remember?"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells>
                   <value>1</value>
-                  <label>"Break the windows of the whole city"</label>
+                  <label>
+                     <value>"Break the windows of the whole city"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6m5n0" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING11"/>
                   <bindingDependencies>CLOWNING11</bindingDependencies>
@@ -1441,24 +2110,39 @@
             <cells type="line">
                <cells>
                   <value>2</value>
-                  <label>"Loose the violin of his daughter playing poker"</label>
+                  <label>
+                     <value>"Loose the violin of his daughter playing poker"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6l29o" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING21"/>
                   <bindingDependencies>CLOWNING21</bindingDependencies>
@@ -1471,24 +2155,39 @@
             <cells type="line">
                <cells>
                   <value>3</value>
-                  <label>"Kill Mr Burns"</label>
+                  <label>
+                     <value>"Kill Mr Burns"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq72biw" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING31"/>
                   <bindingDependencies>CLOWNING31</bindingDependencies>
@@ -1501,24 +2200,39 @@
             <cells type="line">
                <cells>
                   <value>4</value>
-                  <label>"Leaving a mechanical object to control the nuclear power plant"</label>
+                  <label>
+                     <value>"Leaving a mechanical object to control the nuclear power plant"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6mlan" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING41"/>
                   <bindingDependencies>CLOWNING41</bindingDependencies>
@@ -1534,17 +2248,26 @@
                   componentType="Subsequence"
                   id="j6qeh91y"
                   goToPage="27">
-         <label>"Transport"</label>
+         <label>
+            <value>"Transport"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qeh91y" page="27">
-               <label>"Transport"</label>
+               <label>
+                  <value>"Transport"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
          <components xsi:type="Table"
@@ -1553,11 +2276,17 @@
                      positioning="HORIZONTAL"
                      mandatory="false"
                      page="27">
-            <label>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</label>
+            <label>
+               <value>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="INSTRUCTION"
                           id="j6p2lwuj-d10"
                           position="AFTER_QUESTION_TEXT">
-               <label>"Several answers possible: check off all the relevant boxes"</label>
+               <label>
+                  <value>"Several answers possible: check off all the relevant boxes"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -1565,10 +2294,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qeh91y" page="27">
-                  <label>"Transport"</label>
+                  <label>
+                     <value>"Transport"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>TRAVEL11</bindingDependencies>
@@ -1597,31 +2332,55 @@
             <bindingDependencies>TRAVEL46</bindingDependencies>
             <cells type="header">
                <cells headerCell="true">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Brazil"</label>
+                  <label>
+                     <value>"Brazil"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Canada"</label>
+                  <label>
+                     <value>"Canada"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Japan"</label>
+                  <label>
+                     <value>"Japan"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"France"</label>
+                  <label>
+                     <value>"France"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Other country"</label>
+                  <label>
+                     <value>"Other country"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Other planet"</label>
+                  <label>
+                     <value>"Other planet"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells>
                   <value>1</value>
-                  <label>"Car"</label>
+                  <label>
+                     <value>"Car"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvm4qg" componentType="CheckboxBoolean">
                   <response name="TRAVEL11"/>
@@ -1651,7 +2410,10 @@
             <cells type="line">
                <cells>
                   <value>2</value>
-                  <label>"Bike"</label>
+                  <label>
+                     <value>"Bike"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvebem" componentType="CheckboxBoolean">
                   <response name="TRAVEL21"/>
@@ -1681,7 +2443,10 @@
             <cells type="line">
                <cells>
                   <value>3</value>
-                  <label>"Skateboard"</label>
+                  <label>
+                     <value>"Skateboard"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewv62xx" componentType="CheckboxBoolean">
                   <response name="TRAVEL31"/>
@@ -1711,7 +2476,10 @@
             <cells type="line">
                <cells>
                   <value>4</value>
-                  <label>"Plane"</label>
+                  <label>
+                     <value>"Plane"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvjcck" componentType="CheckboxBoolean">
                   <response name="TRAVEL41"/>
@@ -1745,14 +2513,20 @@
                componentType="Sequence"
                id="j6qfx9qe"
                page="28">
-      <label>"V - Favourite characters (dynamic table)"</label>
+      <label>
+         <value>"V - Favourite characters (dynamic table)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qfx9qe" page="28">
-            <label>"V - Favourite characters (dynamic table)"</label>
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="Table"
@@ -1761,14 +2535,20 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="29">
-         <label>"➡ 1. Please, complete the following grid with your favourite characters"</label>
+         <label>
+            <value>"➡ 1. Please, complete the following grid with your favourite characters"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>FAVOURITE_CHAR1</bindingDependencies>
@@ -1807,13 +2587,22 @@
          <lines min="1" max="10"/>
          <cells type="header">
             <cells headerCell="true">
-               <label>"Name"</label>
+               <label>
+                  <value>"Name"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Age"</label>
+               <label>
+                  <value>"Age"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Member of the Simpsons family"</label>
+               <label>
+                  <value>"Member of the Simpsons family"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
          </cells>
          <cells type="line">
@@ -1832,15 +2621,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_1_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_1_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
@@ -1862,15 +2660,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_2_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_2_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
@@ -1892,15 +2699,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_3_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_3_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
@@ -1922,15 +2738,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_4_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_4_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
@@ -1952,15 +2777,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_5_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_5_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
@@ -1982,15 +2816,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_6_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_6_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
@@ -2012,15 +2855,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_7_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_7_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
@@ -2042,15 +2894,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_8_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_8_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
@@ -2072,15 +2933,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_9_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_9_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
@@ -2102,15 +2972,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_10_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_10_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
@@ -2123,14 +3002,20 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="30">
-         <label>"➡ 2. How has your feeling about the following characters evolved over time?"</label>
+         <label>
+            <value>"➡ 2. How has your feeling about the following characters evolved over time?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>FEELCHAREV1</bindingDependencies>
@@ -2140,20 +3025,32 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Jay"</label>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq76emy" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV1"/>
                <bindingDependencies>FEELCHAREV1</bindingDependencies>
@@ -2162,20 +3059,32 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Bart"</label>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq6zv60" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV2"/>
                <bindingDependencies>FEELCHAREV2</bindingDependencies>
@@ -2184,20 +3093,32 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Krusty the clown"</label>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq7bgk3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV3"/>
                <bindingDependencies>FEELCHAREV3</bindingDependencies>
@@ -2206,20 +3127,32 @@
          <cells type="line">
             <cells>
                <value>O</value>
-               <label>"Other"</label>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq6ync3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV4"/>
                <bindingDependencies>FEELCHAREV4</bindingDependencies>
@@ -2232,14 +3165,20 @@
                   positioning="HORIZONTAL"
                   mandatory="false"
                   page="31">
-         <label>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</label>
+         <label>
+            <value>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>LEAVDURATION11</bindingDependencies>
@@ -2254,19 +3193,31 @@
          <bindingDependencies>LEAVDURATION52</bindingDependencies>
          <cells type="header">
             <cells headerCell="true">
-               <label/>
+               <label>
+                  <value/>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Days"</label>
+               <label>
+                  <value>"Days"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Unit"</label>
+               <label>
+                  <value>"Unit"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
          </cells>
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Leave with pay"</label>
+               <label>
+                  <value>"Leave with pay"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv511d"
                    componentType="InputNumber"
@@ -2279,11 +3230,17 @@
             <cells id="jvxwy68n-QOP-kewv20qg" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION12"/>
                <bindingDependencies>LEAVDURATION12</bindingDependencies>
@@ -2292,7 +3249,10 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Public holiday"</label>
+               <label>
+                  <value>"Public holiday"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv67nj"
                    componentType="InputNumber"
@@ -2305,11 +3265,17 @@
             <cells id="jvxwy68n-QOP-kewvizdm" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION22"/>
                <bindingDependencies>LEAVDURATION22</bindingDependencies>
@@ -2318,7 +3284,10 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Sick leave"</label>
+               <label>
+                  <value>"Sick leave"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv23wm"
                    componentType="InputNumber"
@@ -2331,11 +3300,17 @@
             <cells id="jvxwy68n-QOP-kewv9jcl" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION32"/>
                <bindingDependencies>LEAVDURATION32</bindingDependencies>
@@ -2344,7 +3319,10 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Maternity/paternity leave"</label>
+               <label>
+                  <value>"Maternity/paternity leave"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv2jks"
                    componentType="InputNumber"
@@ -2357,11 +3335,17 @@
             <cells id="jvxwy68n-QOP-kewvf0gf" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION42"/>
                <bindingDependencies>LEAVDURATION42</bindingDependencies>
@@ -2370,7 +3354,10 @@
          <cells type="line">
             <cells>
                <value>5</value>
-               <label>"Other type"</label>
+               <label>
+                  <value>"Other type"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewvl896"
                    componentType="InputNumber"
@@ -2383,11 +3370,17 @@
             <cells id="jvxwy68n-QOP-kewvalmd" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION52"/>
                <bindingDependencies>LEAVDURATION52</bindingDependencies>
@@ -2399,14 +3392,20 @@
                componentType="Sequence"
                id="kiq5mr0b"
                page="32">
-      <label>"VI - Favourite characters (Loop)"</label>
+      <label>
+         <value>"VI - Favourite characters (Loop)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="kiq5mr0b" page="32">
-            <label>"VI - Favourite characters (Loop)"</label>
+            <label>
+               <value>"VI - Favourite characters (Loop)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="InputNumber"
@@ -2417,14 +3416,20 @@
                   max="20"
                   decimals="0"
                   page="33">
-         <label>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</label>
+         <label>
+            <value>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NB_CHAR</bindingDependencies>
@@ -2435,14 +3440,20 @@
                   id="kiq7bjam"
                   page="34"
                   paginatedLoop="false">
-         <label>"Add a character"</label>
+         <label>
+            <value>"Add a character"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2452,17 +3463,26 @@
                      id="kiq5u8d5"
                      page="34"
                      goToPage="34">
-            <label>"Description of each character"</label>
+            <label>
+               <value>"Description of each character"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="kiq5mr0b" page="32">
-                  <label>"VI - Favourite characters (Loop)"</label>
+                  <label>
+                     <value>"VI - Favourite characters (Loop)"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="kiq5u8d5" page="34">
-                  <label>"Description of each character"</label>
+                  <label>
+                     <value>"Description of each character"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <components xsi:type="Input"
@@ -2471,17 +3491,26 @@
                         maxLength="30"
                         mandatory="false"
                         page="34">
-               <label>"➡ 2. What is the first name of this character?"</label>
+               <label>
+                  <value>"➡ 2. What is the first name of this character?"</value>
+                  <type>VTL|MD</type>
+               </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
                   <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
+                     <label>
+                        <value>"VI - Favourite characters (Loop)"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </sequence>
                   <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
+                     <label>
+                        <value>"Description of each character"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </subSequence>
                </hierarchy>
                <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2495,17 +3524,26 @@
                         max="120"
                         decimals="0"
                         page="34">
-               <label>"➡ 3. How old is this character in the first episode of the Simpsons family?"</label>
+               <label>
+                  <value>"➡ 3. How old is this character in the first episode of the Simpsons family?"</value>
+                  <type>VTL|MD</type>
+               </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
                   <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
+                     <label>
+                        <value>"VI - Favourite characters (Loop)"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </sequence>
                   <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
+                     <label>
+                        <value>"Description of each character"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </subSequence>
                </hierarchy>
                <bindingDependencies>AGE_CHAR</bindingDependencies>
@@ -2535,14 +3573,20 @@
                   componentType="Sequence"
                   id="kiq5xw5p"
                   page="35.1">
-         <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+         <label>
+            <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5xw5p" page="35.1">
-               <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+               <label>
+                  <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2551,25 +3595,37 @@
                      id="kiq65x3c"
                      mandatory="false"
                      page="35.2">
-            <label>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</label>
+            <label>
+               <value>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+                  <label>
+                     <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
             </hierarchy>
             <bindingDependencies>NAME_CHAR</bindingDependencies>
             <bindingDependencies>FAVCHAR</bindingDependencies>
             <options>
                <value>1</value>
-               <label>"Yes"</label>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
             </options>
             <options>
                <value>0</value>
-               <label>"No"</label>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
             </options>
             <response name="FAVCHAR"/>
          </components>
@@ -2579,14 +3635,20 @@
                      maxLength="255"
                      mandatory="false"
                      page="35.3">
-            <label>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</label>
+            <label>
+               <value>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+                  <label>
+                     <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
             </hierarchy>
             <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2599,13 +3661,19 @@
                componentType="Sequence"
                id="j6z12s2d"
                page="36">
-      <label>"VIII - Comment"</label>
+      <label>
+         <value>"VIII - Comment"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
-            <label>"VIII - Comment"</label>
+            <label>
+               <value>"VIII - Comment"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
       <components xsi:type="Textarea"
@@ -2614,13 +3682,19 @@
                   maxLength="255"
                   mandatory="false"
                   page="37">
-         <label>"➡ 1. Do you have any comment about the survey?"</label>
+         <label>
+            <value>"➡ 1. Do you have any comment about the survey?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6z12s2d" page="36">
-               <label>"VIII - Comment"</label>
+               <label>
+                  <value>"VIII - Comment"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>SURVEY_COMMENT</bindingDependencies>

--- a/src/test/resources/dummy/form_flat.xml
+++ b/src/test/resources/dummy/form_flat.xml
@@ -3610,10 +3610,6 @@
                page="35"
                maxPage="3"
                paginatedLoop="true">
-      <iterations>
-         <value>count(NAME_CHAR)</value>
-         <type>VTL|MD</type>
-      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <type>VTL|MD</type>
@@ -3714,6 +3710,10 @@
          <bindingDependencies>MEMORY_CHAR</bindingDependencies>
          <response name="MEMORY_CHAR"/>
       </components>
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
    </components>
    <components xsi:type="Sequence"
                componentType="Sequence"

--- a/src/test/resources/dummy/form_flat.xml
+++ b/src/test/resources/dummy/form_flat.xml
@@ -6,23 +6,35 @@
                enoCoreVersion="2.2.8"
                pagination="question"
                maxPage="37">
-   <label>Questionnaire SIMPSONS 20201215</label>
+   <label>
+      <value>Questionnaire SIMPSONS 20201215</value>
+      <type>VTL|MD</type>
+   </label>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6p0ti5h"
                page="1">
-      <label>"I - Introduction"</label>
+      <label>
+         <value>"I - Introduction"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j6p0ti5h-d1"
                     position="AFTER_QUESTION_TEXT">
-         <label>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</label>
+         <label>
+            <value>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
-            <label>"I - Introduction"</label>
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -32,72 +44,102 @@
                maxLength="500"
                mandatory="true"
                page="2">
-         <label>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</label>
-         <conditionFilter>
-            <value>true</value>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>COMMENT</bindingDependencies>
-         <response name="COMMENT"/>
-      </components>
+      <label>
+         <value>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>COMMENT</bindingDependencies>
+      <response name="COMMENT"/>
+   </components>
    <components xsi:type="CheckboxBoolean"
                componentType="CheckboxBoolean"
                id="j6p0np9q"
                mandatory="false"
                page="3">
-         <label>"➡ 2. If you agree to answer this questionnaire, please check the box"</label>
-         <declarations declarationType="COMMENT"
+      <label>
+         <value>"➡ 2. If you agree to answer this questionnaire, please check the box"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="COMMENT"
                     id="j6p0np9q-kir6xl1e"
                     position="AFTER_QUESTION_TEXT">
-            <label>"If not, this is unfortunately the end of this questionnaire."</label>
-         </declarations>
-         <conditionFilter>
-            <value>true</value>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>READY</bindingDependencies>
-         <response name="READY"/>
-      </components>
+         <label>
+            <value>"If not, this is unfortunately the end of this questionnaire."</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>true</value>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>READY</bindingDependencies>
+      <response name="READY"/>
+   </components>
    <components xsi:type="FilterDescription"
                componentType="FilterDescription"
                id="j6p6my1d"
                filterDescription="false"
                page="3">
-         <label>"If you are not ready, please go to the end of the questionnaire"</label>
-         <conditionFilter>
-            <value>true</value>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
-            </sequence>
-         </hierarchy>
-      </components>
+      <label>
+         <value>"If you are not ready, please go to the end of the questionnaire"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+   </components>
    <components xsi:type="Subsequence"
                componentType="Subsequence"
                id="j6p0s7o5"
                goToPage="4">
-      <label>"General knowledge of the series"</label>
+      <label>
+         <value>"General knowledge of the series"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
       <hierarchy>
-            <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
-            </sequence>
-            <subSequence id="j6p0s7o5" page="4">
-               <label>"General knowledge of the series"</label>
-            </subSequence>
-         </hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
    </components>
    <components xsi:type="Input"
                componentType="Input"
@@ -105,22 +147,31 @@
                maxLength="30"
                mandatory="false"
                page="4">
-            <label>"➡ 3. Who is the producer?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>PRODUCER</bindingDependencies>
-            <response name="PRODUCER"/>
-         </components>
+      <label>
+         <value>"➡ 3. Who is the producer?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>PRODUCER</bindingDependencies>
+      <response name="PRODUCER"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="j6q9h8tj"
@@ -129,22 +180,31 @@
                max="99"
                decimals="0"
                page="5">
-            <label>"➡ 4. What is the current season number?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>SEASON_NUMBER</bindingDependencies>
-            <response name="SEASON_NUMBER"/>
-         </components>
+      <label>
+         <value>"➡ 4. What is the current season number?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>SEASON_NUMBER</bindingDependencies>
+      <response name="SEASON_NUMBER"/>
+   </components>
    <components xsi:type="Datepicker"
                componentType="Datepicker"
                id="kiq71eoi"
@@ -152,56 +212,80 @@
                min="1900-01-01"
                max="format-date(current-date(),'[Y0001]-[M01]-[D01]')"
                page="6">
-            <label>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</label>
-            <declarations declarationType="INSTRUCTION"
+      <label>
+         <value>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="INSTRUCTION"
                     id="kiq71eoi-kiq7dsy2"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM-DD format"</label>
-            </declarations>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DATEFIRST</bindingDependencies>
-            <dateFormat>YYYY-MM-DD</dateFormat>
-            <response name="DATEFIRST"/>
-         </components>
+         <label>
+            <value>"Please answer with YYYY-MM-DD format"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DATEFIRST</bindingDependencies>
+      <dateFormat>YYYY-MM-DD</dateFormat>
+      <response name="DATEFIRST"/>
+   </components>
    <components xsi:type="Datepicker"
                componentType="Datepicker"
                id="k5nvty2o"
                mandatory="false"
                min="1980-05"
                page="7">
-            <label>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</label>
-            <declarations declarationType="COMMENT"
+      <label>
+         <value>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="COMMENT"
                     id="k5nvty2o-k5nvxld8"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM format"</label>
-            </declarations>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DATEYYYYMM</bindingDependencies>
-            <dateFormat>YYYY-MM</dateFormat>
-            <response name="DATEYYYYMM"/>
-         </components>
+         <label>
+            <value>"Please answer with YYYY-MM format"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DATEYYYYMM</bindingDependencies>
+      <dateFormat>YYYY-MM</dateFormat>
+      <response name="DATEYYYYMM"/>
+   </components>
    <components xsi:type="Datepicker"
                componentType="Datepicker"
                id="k5nw1fir"
@@ -209,28 +293,40 @@
                min="1900"
                max="year-from-date(current-date())"
                page="8">
-            <label>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</label>
-            <declarations declarationType="COMMENT"
+      <label>
+         <value>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="COMMENT"
                     id="k5nw1fir-k5nvmx3n"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY format"</label>
-            </declarations>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DATEYYYY</bindingDependencies>
-            <dateFormat>YYYY</dateFormat>
-            <response name="DATEYYYY"/>
-         </components>
+         <label>
+            <value>"Please answer with YYYY format"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DATEYYYY</bindingDependencies>
+      <dateFormat>YYYY</dateFormat>
+      <response name="DATEYYYY"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="k5nw0w05"
@@ -239,23 +335,32 @@
                max="70.00"
                decimals="2"
                page="9">
-            <label>"➡ 8. How long does an episode last?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DURATIONH</bindingDependencies>
-            <unit>heures</unit>
-            <response name="DURATIONH"/>
-         </components>
+      <label>
+         <value>"➡ 8. How long does an episode last?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DURATIONH</bindingDependencies>
+      <unit>heures</unit>
+      <response name="DURATIONH"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="k5nvu98z"
@@ -264,23 +369,32 @@
                max="366.0"
                decimals="1"
                page="10">
-            <label>"➡ 9. How long does it take to write a new episode?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DURATIOND</bindingDependencies>
-            <unit>jours</unit>
-            <response name="DURATIOND"/>
-         </components>
+      <label>
+         <value>"➡ 9. How long does it take to write a new episode?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DURATIOND</bindingDependencies>
+      <unit>jours</unit>
+      <response name="DURATIOND"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="k5nw8ei1"
@@ -289,23 +403,32 @@
                max="12"
                decimals="0"
                page="11">
-            <label>"➡ 10. How long will it take you to watch all the existing episodes?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DURATIONM</bindingDependencies>
-            <unit>mois</unit>
-            <response name="DURATIONM"/>
-         </components>
+      <label>
+         <value>"➡ 10. How long will it take you to watch all the existing episodes?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DURATIONM</bindingDependencies>
+      <unit>mois</unit>
+      <response name="DURATIONM"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="k5nw9dk4"
@@ -314,23 +437,32 @@
                max="100"
                decimals="0"
                page="12">
-            <label>"➡ 11. For how long have you known the Simpsons family?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>DURATIONY</bindingDependencies>
-            <unit>années</unit>
-            <response name="DURATIONY"/>
-         </components>
+      <label>
+         <value>"➡ 11. For how long have you known the Simpsons family?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>DURATIONY</bindingDependencies>
+      <unit>années</unit>
+      <response name="DURATIONY"/>
+   </components>
    <components xsi:type="InputNumber"
                componentType="InputNumber"
                id="j6z06z1e"
@@ -339,32 +471,47 @@
                max="99.0"
                decimals="1"
                page="13">
-            <label>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
-               </sequence>
-               <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
-               </subSequence>
-            </hierarchy>
-            <bindingDependencies>AUDIENCE_SHARE</bindingDependencies>
-            <unit>%</unit>
-            <response name="AUDIENCE_SHARE"/>
-         </components>
+      <label>
+         <value>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6p0ti5h" page="1">
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6p0s7o5" page="4">
+            <label>
+               <value>"General knowledge of the series"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>AUDIENCE_SHARE</bindingDependencies>
+      <unit>%</unit>
+      <response name="AUDIENCE_SHARE"/>
+   </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j3341528"
                page="14">
-      <label>"II - Simpsons’ city"</label>
+      <label>
+         <value>"II - Simpsons’ city"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j3341528-d2"
                     position="AFTER_QUESTION_TEXT">
-         <label>"This module asks about your general knowledge of the Simpsons city"</label>
+         <label>
+            <value>"This module asks about your general knowledge of the Simpsons city"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -372,7 +519,10 @@
       </conditionFilter>
       <hierarchy>
          <sequence id="j3341528" page="14">
-            <label>"II - Simpsons’ city"</label>
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -381,157 +531,247 @@
                id="j3343clt"
                mandatory="true"
                page="15">
-         <label>"➡ 1. In which city do the Simpsons reside?"</label>
-         <declarations declarationType="INSTRUCTION"
+      <label>
+         <value>"➡ 1. In which city do the Simpsons reside?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="INSTRUCTION"
                     id="j3343clt-d3"
                     position="AFTER_QUESTION_TEXT">
-            <label>"One possible answer"</label>
-         </declarations>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>CITY</bindingDependencies>
-         <options>
-            <value>00001</value>
-            <label>"Springfield"</label>
-         </options>
-         <options>
-            <value>00002</value>
-            <label>"Shelbyville"</label>
-         </options>
-         <options>
-            <value>03</value>
-            <label>"Seinfeld"</label>
-         </options>
-         <response name="CITY"/>
-      </components>
+         <label>
+            <value>"One possible answer"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j3341528" page="14">
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>CITY</bindingDependencies>
+      <options>
+         <value>00001</value>
+         <label>
+            <value>"Springfield"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>00002</value>
+         <label>
+            <value>"Shelbyville"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>03</value>
+         <label>
+            <value>"Seinfeld"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <response name="CITY"/>
+   </components>
    <components xsi:type="CheckboxOne"
                componentType="CheckboxOne"
                id="j6qdfhvw"
                mandatory="false"
                page="16">
-         <label>"➡ 2. Who is the Simpsons city mayor?"</label>
-         <declarations declarationType="INSTRUCTION"
+      <label>
+         <value>"➡ 2. Who is the Simpsons city mayor?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="INSTRUCTION"
                     id="j6qdfhvw-d4"
                     position="AFTER_QUESTION_TEXT">
-            <label>"Only one possible answer"</label>
-         </declarations>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>MAYOR</bindingDependencies>
-         <options>
-            <value>1</value>
-            <label>"Constance Harm"</label>
-         </options>
-         <options>
-            <value>2</value>
-            <label>"Timothy Lovejoy"</label>
-         </options>
-         <options>
-            <value>3</value>
-            <label>"Joe Quimby"</label>
-         </options>
-         <options>
-            <value>OT</value>
-            <label>"Other name"</label>
-         </options>
-         <response name="MAYOR"/>
-      </components>
+         <label>
+            <value>"Only one possible answer"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j3341528" page="14">
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>MAYOR</bindingDependencies>
+      <options>
+         <value>1</value>
+         <label>
+            <value>"Constance Harm"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>2</value>
+         <label>
+            <value>"Timothy Lovejoy"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>3</value>
+         <label>
+            <value>"Joe Quimby"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>OT</value>
+         <label>
+            <value>"Other name"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <response name="MAYOR"/>
+   </components>
    <components xsi:type="Dropdown"
                componentType="Dropdown"
                id="j4nw5cqz"
                mandatory="false"
                page="17">
-         <label>"➡ 3. In which state do The Simpsons reside?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>STATE</bindingDependencies>
-         <options>
-            <value>1</value>
-            <label>"Washington"</label>
-         </options>
-         <options>
-            <value>2</value>
-            <label>"Kentucky"</label>
-         </options>
-         <options>
-            <value>3</value>
-            <label>"Ohio"</label>
-         </options>
-         <options>
-            <value>4</value>
-            <label>"Maine"</label>
-         </options>
-         <options>
-            <value>5</value>
-            <label>"North Dakota"</label>
-         </options>
-         <options>
-            <value>6</value>
-            <label>"Florida"</label>
-         </options>
-         <options>
-            <value>7</value>
-            <label>"North Takoma"</label>
-         </options>
-         <options>
-            <value>8</value>
-            <label>"California"</label>
-         </options>
-         <options>
-            <value>9</value>
-            <label>"Texas"</label>
-         </options>
-         <options>
-            <value>10</value>
-            <label>"Massachusetts"</label>
-         </options>
-         <options>
-            <value>11</value>
-            <label>"Nevada"</label>
-         </options>
-         <options>
-            <value>12</value>
-            <label>"Illinois"</label>
-         </options>
-         <options>
-            <value>13</value>
-            <label>"Not in any state, you fool!"</label>
-         </options>
-         <response name="STATE"/>
-      </components>
+      <label>
+         <value>"➡ 3. In which state do The Simpsons reside?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j3341528" page="14">
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>STATE</bindingDependencies>
+      <options>
+         <value>1</value>
+         <label>
+            <value>"Washington"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>2</value>
+         <label>
+            <value>"Kentucky"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>3</value>
+         <label>
+            <value>"Ohio"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>4</value>
+         <label>
+            <value>"Maine"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>5</value>
+         <label>
+            <value>"North Dakota"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>6</value>
+         <label>
+            <value>"Florida"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>7</value>
+         <label>
+            <value>"North Takoma"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>8</value>
+         <label>
+            <value>"California"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>9</value>
+         <label>
+            <value>"Texas"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>10</value>
+         <label>
+            <value>"Massachusetts"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>11</value>
+         <label>
+            <value>"Nevada"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>12</value>
+         <label>
+            <value>"Illinois"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <options>
+         <value>13</value>
+         <label>
+            <value>"Not in any state, you fool!"</value>
+            <type>VTL|MD</type>
+         </label>
+      </options>
+      <response name="STATE"/>
+   </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6qe0h9q"
                page="18">
-      <label>"III - Characters"</label>
+      <label>
+         <value>"III - Characters"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qe0h9q" page="18">
-            <label>"III - Characters"</label>
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -539,417 +779,627 @@
                componentType="CheckboxGroup"
                id="j334akov"
                page="19">
-         <label>"➡ 1. What are the pet names that the Simpsons family had?"</label>
-         <declarations declarationType="INSTRUCTION"
+      <label>
+         <value>"➡ 1. What are the pet names that the Simpsons family had?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="INSTRUCTION"
                     id="j334akov-d5"
                     position="AFTER_QUESTION_TEXT">
-            <label>"Several possible answers"</label>
-         </declarations>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>PET1</bindingDependencies>
-         <bindingDependencies>PET2</bindingDependencies>
-         <bindingDependencies>PET3</bindingDependencies>
-         <bindingDependencies>PET4</bindingDependencies>
-         <responses id="j334akov-QOP-khokqjtw">
-            <label>"Santa’s Little Helper"</label>
-            <response name="PET1"/>
-         </responses>
-         <responses id="j334akov-QOP-khokur7a">
-            <label>"Snowball I"</label>
-            <response name="PET2"/>
-         </responses>
-         <responses id="j334akov-QOP-khol82ux">
-            <label>"Coltrane"</label>
-            <response name="PET3"/>
-         </responses>
-         <responses id="j334akov-QOP-khokqee5">
-            <label>"Other name"</label>
-            <response name="PET4"/>
-         </responses>
-      </components>
+         <label>
+            <value>"Several possible answers"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qe0h9q" page="18">
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>PET1</bindingDependencies>
+      <bindingDependencies>PET2</bindingDependencies>
+      <bindingDependencies>PET3</bindingDependencies>
+      <bindingDependencies>PET4</bindingDependencies>
+      <responses id="j334akov-QOP-khokqjtw">
+         <label>
+            <value>"Santa’s Little Helper"</value>
+            <type>VTL|MD</type>
+         </label>
+         <response name="PET1"/>
+      </responses>
+      <responses id="j334akov-QOP-khokur7a">
+         <label>
+            <value>"Snowball I"</value>
+            <type>VTL|MD</type>
+         </label>
+         <response name="PET2"/>
+      </responses>
+      <responses id="j334akov-QOP-khol82ux">
+         <label>
+            <value>"Coltrane"</value>
+            <type>VTL|MD</type>
+         </label>
+         <response name="PET3"/>
+      </responses>
+      <responses id="j334akov-QOP-khokqee5">
+         <label>
+            <value>"Other name"</value>
+            <type>VTL|MD</type>
+         </label>
+         <response name="PET4"/>
+      </responses>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="j6p29i81"
                positioning="HORIZONTAL"
                mandatory="false"
                page="20">
-         <label>"➡ 2. Does Jay like the following ice cream flavours?"</label>
-         <declarations declarationType="STATEMENT"
+      <label>
+         <value>"➡ 2. Does Jay like the following ice cream flavours?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="STATEMENT"
                     id="d12-SI"
                     position="BEFORE_QUESTION_TEXT">
-            <label>"Now we are going to know if you think that Jay is a gluton."</label>
-         </declarations>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
-         <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
-         <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
-         <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
-         <cells type="line">
-            <cells>
+         <label>
+            <value>"Now we are going to know if you think that Jay is a gluton."</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qe0h9q" page="18">
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
+      <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
+      <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
+      <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Vanilla"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p29i81-QOP-kiq5w99y" componentType="Radio">
+            <options>
                <value>1</value>
-               <label>"Vanilla"</label>
-            </cells>
-            <cells id="j6p29i81-QOP-kiq5w99y" componentType="Radio">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="ICE_FLAVOUR1"/>
-               <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
-            </cells>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="ICE_FLAVOUR1"/>
+            <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>2</value>
-               <label>"Strawberry"</label>
-            </cells>
-            <cells id="j6p29i81-QOP-kiq5ummf" componentType="Radio">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="ICE_FLAVOUR2"/>
-               <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
-            </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Strawberry"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>3</value>
-               <label>"Apple"</label>
-            </cells>
-            <cells id="j6p29i81-QOP-kiq5mry5" componentType="Radio">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="ICE_FLAVOUR3"/>
-               <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
-            </cells>
+         <cells id="j6p29i81-QOP-kiq5ummf" componentType="Radio">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="ICE_FLAVOUR2"/>
+            <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>OT</value>
-               <label>"Other flavour"</label>
-            </cells>
-            <cells id="j6p29i81-QOP-kiq5lkr8" componentType="Radio">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="ICE_FLAVOUR4"/>
-               <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
-            </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Apple"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-      </components>
+         <cells id="j6p29i81-QOP-kiq5mry5" componentType="Radio">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="ICE_FLAVOUR3"/>
+            <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>OT</value>
+            <label>
+               <value>"Other flavour"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p29i81-QOP-kiq5lkr8" componentType="Radio">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="ICE_FLAVOUR4"/>
+            <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="j6qefnga"
                positioning="HORIZONTAL"
                mandatory="false"
                page="21">
-         <label>"➡ 3. Which character works in the nuclear power plant?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
-         <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
-         <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
-         <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
-         <cells type="line">
-            <cells>
+      <label>
+         <value>"➡ 3. Which character works in the nuclear power plant?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qe0h9q" page="18">
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
+      <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
+      <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
+      <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Charles Montgomery Burns"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6qefnga-QOP-kewva8xg" componentType="Dropdown">
+            <options>
                <value>1</value>
-               <label>"Charles Montgomery Burns"</label>
-            </cells>
-            <cells id="j6qefnga-QOP-kewva8xg" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="NUCLEAR_CHARACTER1"/>
-               <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
-            </cells>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="NUCLEAR_CHARACTER1"/>
+            <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>2</value>
-               <label>"Carl Carlson"</label>
-            </cells>
-            <cells id="j6qefnga-QOP-kewvj0ad" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="NUCLEAR_CHARACTER2"/>
-               <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
-            </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Carl Carlson"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>3</value>
-               <label>"Otto Mann"</label>
-            </cells>
-            <cells id="j6qefnga-QOP-kewveltm" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="NUCLEAR_CHARACTER3"/>
-               <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
-            </cells>
+         <cells id="j6qefnga-QOP-kewvj0ad" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="NUCLEAR_CHARACTER2"/>
+            <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>4</value>
-               <label>"Lenny Leonard"</label>
-            </cells>
-            <cells id="j6qefnga-QOP-kewvgax4" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>0</value>
-                  <label>"No"</label>
-               </options>
-               <response name="NUCLEAR_CHARACTER4"/>
-               <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
-            </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Otto Mann"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-      </components>
+         <cells id="j6qefnga-QOP-kewveltm" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="NUCLEAR_CHARACTER3"/>
+            <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>4</value>
+            <label>
+               <value>"Lenny Leonard"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6qefnga-QOP-kewvgax4" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>0</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="NUCLEAR_CHARACTER4"/>
+            <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="j6yzoc6g"
                positioning="HORIZONTAL"
                mandatory="false"
                page="22">
-         <label>"➡ 4. In which city each character was born?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
-         <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
-         <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
-         <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
-         <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
-         <cells type="line">
-            <cells>
+      <label>
+         <value>"➡ 4. In which city each character was born?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qe0h9q" page="18">
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
+      <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
+      <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
+      <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
+      <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Selma Bouvier"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6yzoc6g-QOP-kewvjvcs" componentType="CheckboxOne">
+            <options>
                <value>1</value>
-               <label>"Selma Bouvier"</label>
-            </cells>
-            <cells id="j6yzoc6g-QOP-kewvjvcs" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Albuquerque"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Springfield"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Portland"</label>
-               </options>
-               <options>
-                  <value>4</value>
-                  <label>"Shelbyville"</label>
-               </options>
-               <options>
-                  <value>5</value>
-                  <label>"Dagstuhl"</label>
-               </options>
-               <response name="BIRTH_CHARACTER1"/>
-               <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Albuquerque"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>2</value>
-               <label>"Kent Brockman"</label>
-            </cells>
-            <cells id="j6yzoc6g-QOP-kewvhoda" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Albuquerque"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Springfield"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Portland"</label>
-               </options>
-               <options>
-                  <value>4</value>
-                  <label>"Shelbyville"</label>
-               </options>
-               <options>
-                  <value>5</value>
-                  <label>"Dagstuhl"</label>
-               </options>
-               <response name="BIRTH_CHARACTER2"/>
-               <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Springfield"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>3</value>
-               <label>"Milhouse Van Houten"</label>
-            </cells>
-            <cells id="j6yzoc6g-QOP-kewv64s5" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Albuquerque"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Springfield"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Portland"</label>
-               </options>
-               <options>
-                  <value>4</value>
-                  <label>"Shelbyville"</label>
-               </options>
-               <options>
-                  <value>5</value>
-                  <label>"Dagstuhl"</label>
-               </options>
-               <response name="BIRTH_CHARACTER3"/>
-               <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Portland"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>4</value>
-               <label>"Nelson Muntz"</label>
-            </cells>
-            <cells id="j6yzoc6g-QOP-kewvj21j" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Albuquerque"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Springfield"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Portland"</label>
-               </options>
-               <options>
-                  <value>4</value>
-                  <label>"Shelbyville"</label>
-               </options>
-               <options>
-                  <value>5</value>
-                  <label>"Dagstuhl"</label>
-               </options>
-               <response name="BIRTH_CHARACTER4"/>
-               <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Shelbyville"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>5</value>
-               <label>"Crazy Cat Lady"</label>
-            </cells>
-            <cells id="j6yzoc6g-QOP-kewva5uf" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Albuquerque"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Springfield"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Portland"</label>
-               </options>
-               <options>
-                  <value>4</value>
-                  <label>"Shelbyville"</label>
-               </options>
-               <options>
-                  <value>5</value>
-                  <label>"Dagstuhl"</label>
-               </options>
-               <response name="BIRTH_CHARACTER5"/>
-               <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
-            </cells>
+               <label>
+                  <value>"Dagstuhl"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="BIRTH_CHARACTER1"/>
+            <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
          </cells>
-      </components>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Kent Brockman"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6yzoc6g-QOP-kewvhoda" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Albuquerque"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Springfield"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Portland"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>4</value>
+               <label>
+                  <value>"Shelbyville"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>5</value>
+               <label>
+                  <value>"Dagstuhl"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="BIRTH_CHARACTER2"/>
+            <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Milhouse Van Houten"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6yzoc6g-QOP-kewv64s5" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Albuquerque"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Springfield"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Portland"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>4</value>
+               <label>
+                  <value>"Shelbyville"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>5</value>
+               <label>
+                  <value>"Dagstuhl"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="BIRTH_CHARACTER3"/>
+            <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>4</value>
+            <label>
+               <value>"Nelson Muntz"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6yzoc6g-QOP-kewvj21j" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Albuquerque"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Springfield"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Portland"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>4</value>
+               <label>
+                  <value>"Shelbyville"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>5</value>
+               <label>
+                  <value>"Dagstuhl"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="BIRTH_CHARACTER4"/>
+            <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>5</value>
+            <label>
+               <value>"Crazy Cat Lady"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6yzoc6g-QOP-kewva5uf" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Albuquerque"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Springfield"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Portland"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>4</value>
+               <label>
+                  <value>"Shelbyville"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>5</value>
+               <label>
+                  <value>"Dagstuhl"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="BIRTH_CHARACTER5"/>
+            <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j4nw88h2"
                page="23">
-      <label>"IV - General questions"</label>
+      <label>
+         <value>"IV - General questions"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j4nw88h2" page="23">
-            <label>"IV - General questions"</label>
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -957,19 +1407,28 @@
                componentType="Subsequence"
                id="j6qe237q"
                goToPage="24">
-      <label>"Kwik-E-Mart"</label>
+      <label>
+         <value>"Kwik-E-Mart"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
       <hierarchy>
-            <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
-            </sequence>
-            <subSequence id="j6qe237q" page="24">
-               <label>"Kwik-E-Mart"</label>
-            </subSequence>
-         </hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qe237q" page="24">
+            <label>
+               <value>"Kwik-E-Mart"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
    </components>
    <components xsi:type="Table"
                componentType="Table"
@@ -977,400 +1436,577 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="24">
-            <label>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
-               </sequence>
-               <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
-               </subSequence>
-            </hierarchy>
+      <label>
+         <value>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qe237q" page="24">
+            <label>
+               <value>"Kwik-E-Mart"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>PERCENTAGE_EXPENSES11</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES21</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES31</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES41</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES51</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES61</bindingDependencies>
+      <bindingDependencies>PERCENTAGE_EXPENSES71</bindingDependencies>
+      <cells type="header">
+         <cells headerCell="true" colspan="2">
+            <label>
+               <value/>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Percentage"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells rowspan="2">
+            <value>A</value>
+            <label>
+               <value>"Frozen products"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>A1</value>
+            <label>
+               <value>"Ice creams"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewv2h3o"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES11"/>
             <bindingDependencies>PERCENTAGE_EXPENSES11</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>A2</value>
+            <label>
+               <value>"Jasper Beardly"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewvka2j"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES21"/>
             <bindingDependencies>PERCENTAGE_EXPENSES21</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells rowspan="3">
+            <value>B</value>
+            <label>
+               <value>"Meat"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>B1</value>
+            <label>
+               <value>"Bacon"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewv1f2a"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES31"/>
             <bindingDependencies>PERCENTAGE_EXPENSES31</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>B2</value>
+            <label>
+               <value>"Pork chop"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewvb2ql"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES41"/>
             <bindingDependencies>PERCENTAGE_EXPENSES41</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>B3</value>
+            <label>
+               <value>"Chicken"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewvbxla"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES51"/>
             <bindingDependencies>PERCENTAGE_EXPENSES51</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>C</value>
+            <label>
+               <value>"Compote"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>C1</value>
+            <label>
+               <value>"Powersauce"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewvkjp0"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES61"/>
             <bindingDependencies>PERCENTAGE_EXPENSES61</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells colspan="2">
+            <value>D</value>
+            <label>
+               <value>"Other"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j4nwc63q-QOP-kewv2cyx"
+                componentType="InputNumber"
+                min="0.0"
+                max="100.0"
+                decimals="1">
+            <unit>%</unit>
+            <response name="PERCENTAGE_EXPENSES71"/>
             <bindingDependencies>PERCENTAGE_EXPENSES71</bindingDependencies>
-            <cells type="header">
-               <cells headerCell="true" colspan="2">
-                  <label/>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Percentage"</label>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells rowspan="2">
-                  <value>A</value>
-                  <label>"Frozen products"</label>
-               </cells>
-               <cells>
-                  <value>A1</value>
-                  <label>"Ice creams"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewv2h3o"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES11"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES11</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>A2</value>
-                  <label>"Jasper Beardly"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewvka2j"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES21"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES21</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells rowspan="3">
-                  <value>B</value>
-                  <label>"Meat"</label>
-               </cells>
-               <cells>
-                  <value>B1</value>
-                  <label>"Bacon"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewv1f2a"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES31"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES31</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>B2</value>
-                  <label>"Pork chop"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewvb2ql"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES41"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES41</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>B3</value>
-                  <label>"Chicken"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewvbxla"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES51"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES51</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>C</value>
-                  <label>"Compote"</label>
-               </cells>
-               <cells>
-                  <value>C1</value>
-                  <label>"Powersauce"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewvkjp0"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES61"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES61</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells colspan="2">
-                  <value>D</value>
-                  <label>"Other"</label>
-               </cells>
-               <cells id="j4nwc63q-QOP-kewv2cyx"
-                componentType="InputNumber"
-                min="0.0"
-                max="100.0"
-                decimals="1">
-                  <unit>%</unit>
-                  <response name="PERCENTAGE_EXPENSES71"/>
-                  <bindingDependencies>PERCENTAGE_EXPENSES71</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells colspan="2">
-                  <value>E</value>
-                  <label>"Total"</label>
-               </cells>
-               <cells headerCell="false"/>
-            </cells>
-         </components>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells colspan="2">
+            <value>E</value>
+            <label>
+               <value>"Total"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="false"/>
+      </cells>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="k9cg2q5t"
                positioning="HORIZONTAL"
                mandatory="false"
                page="25">
-            <label>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
-               </sequence>
-               <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
-               </subSequence>
-            </hierarchy>
+      <label>
+         <value>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qe237q" page="24">
+            <label>
+               <value>"Kwik-E-Mart"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING21</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING31</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING41</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING51</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING61</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING71</bindingDependencies>
+      <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
+      <cells type="header">
+         <cells headerCell="true" colspan="2">
+            <label>
+               <value/>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"In his last food shopping"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells rowspan="2">
+            <value>A</value>
+            <label>
+               <value>"Frozen products"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>A1</value>
+            <label>
+               <value>"Ice creams"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6pljq" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING11"/>
             <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>A2</value>
+            <label>
+               <value>"Jasper Beardly"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6mgpv" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING21"/>
             <bindingDependencies>LAST_FOOD_SHOPPING21</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells rowspan="3">
+            <value>B</value>
+            <label>
+               <value>"Meat"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>B1</value>
+            <label>
+               <value>"Bacon"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6pmtz" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING31"/>
             <bindingDependencies>LAST_FOOD_SHOPPING31</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>B2</value>
+            <label>
+               <value>"Pork chop"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6k4lf" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING41"/>
             <bindingDependencies>LAST_FOOD_SHOPPING41</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>B3</value>
+            <label>
+               <value>"Chicken"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6p70n" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING51"/>
             <bindingDependencies>LAST_FOOD_SHOPPING51</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>C</value>
+            <label>
+               <value>"Compote"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells>
+            <value>C1</value>
+            <label>
+               <value>"Powersauce"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6lh5v" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING61"/>
             <bindingDependencies>LAST_FOOD_SHOPPING61</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells colspan="2">
+            <value>D</value>
+            <label>
+               <value>"Other"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq703te" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING71"/>
             <bindingDependencies>LAST_FOOD_SHOPPING71</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells colspan="2">
+            <value>E</value>
+            <label>
+               <value>"Total"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="k9cg2q5t-QOP-kiq6zpd3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LAST_FOOD_SHOPPING81"/>
             <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
-            <cells type="header">
-               <cells headerCell="true" colspan="2">
-                  <label/>
-               </cells>
-               <cells headerCell="true">
-                  <label>"In his last food shopping"</label>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells rowspan="2">
-                  <value>A</value>
-                  <label>"Frozen products"</label>
-               </cells>
-               <cells>
-                  <value>A1</value>
-                  <label>"Ice creams"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6pljq" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING11"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>A2</value>
-                  <label>"Jasper Beardly"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6mgpv" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING21"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING21</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells rowspan="3">
-                  <value>B</value>
-                  <label>"Meat"</label>
-               </cells>
-               <cells>
-                  <value>B1</value>
-                  <label>"Bacon"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6pmtz" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING31"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING31</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>B2</value>
-                  <label>"Pork chop"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6k4lf" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING41"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING41</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>B3</value>
-                  <label>"Chicken"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6p70n" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING51"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING51</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>C</value>
-                  <label>"Compote"</label>
-               </cells>
-               <cells>
-                  <value>C1</value>
-                  <label>"Powersauce"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6lh5v" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING61"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING61</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells colspan="2">
-                  <value>D</value>
-                  <label>"Other"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq703te" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING71"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING71</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells colspan="2">
-                  <value>E</value>
-                  <label>"Total"</label>
-               </cells>
-               <cells id="k9cg2q5t-QOP-kiq6zpd3" componentType="CheckboxOne">
-                  <options>
-                     <value>1</value>
-                     <label>"Yes"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"No"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="LAST_FOOD_SHOPPING81"/>
-                  <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
-               </cells>
-            </cells>
-         </components>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Subsequence"
                componentType="Subsequence"
                id="j6qejudb"
                goToPage="26">
-      <label>"Clowning"</label>
+      <label>
+         <value>"Clowning"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
       <hierarchy>
-            <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
-            </sequence>
-            <subSequence id="j6qejudb" page="26">
-               <label>"Clowning"</label>
-            </subSequence>
-         </hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qejudb" page="26">
+            <label>
+               <value>"Clowning"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
    </components>
    <components xsi:type="Table"
                componentType="Table"
@@ -1378,176 +2014,263 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="26">
-            <label>"➡ 3. Who did these clownings and tell us what you remember?"</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
-               </sequence>
-               <subSequence id="j6qejudb" page="26">
-                  <label>"Clowning"</label>
-               </subSequence>
-            </hierarchy>
+      <label>
+         <value>"➡ 3. Who did these clownings and tell us what you remember?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qejudb" page="26">
+            <label>
+               <value>"Clowning"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>CLOWNING11</bindingDependencies>
+      <bindingDependencies>CLOWNING12</bindingDependencies>
+      <bindingDependencies>CLOWNING21</bindingDependencies>
+      <bindingDependencies>CLOWNING22</bindingDependencies>
+      <bindingDependencies>CLOWNING31</bindingDependencies>
+      <bindingDependencies>CLOWNING32</bindingDependencies>
+      <bindingDependencies>CLOWNING41</bindingDependencies>
+      <bindingDependencies>CLOWNING42</bindingDependencies>
+      <cells type="header">
+         <cells headerCell="true">
+            <label>
+               <value/>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Clowning"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Remember?"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Break the windows of the whole city"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6m5n0" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>O</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="CLOWNING11"/>
             <bindingDependencies>CLOWNING11</bindingDependencies>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6qatu" componentType="Textarea" maxLength="255">
+            <response name="CLOWNING12"/>
             <bindingDependencies>CLOWNING12</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Loose the violin of his daughter playing poker"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6l29o" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>O</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="CLOWNING21"/>
             <bindingDependencies>CLOWNING21</bindingDependencies>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6v4oe" componentType="Textarea" maxLength="255">
+            <response name="CLOWNING22"/>
             <bindingDependencies>CLOWNING22</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Kill Mr Burns"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq72biw" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>O</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="CLOWNING31"/>
             <bindingDependencies>CLOWNING31</bindingDependencies>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6q4zm" componentType="Textarea" maxLength="255">
+            <response name="CLOWNING32"/>
             <bindingDependencies>CLOWNING32</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>4</value>
+            <label>
+               <value>"Leaving a mechanical object to control the nuclear power plant"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6mlan" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>O</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="CLOWNING41"/>
             <bindingDependencies>CLOWNING41</bindingDependencies>
+         </cells>
+         <cells id="kbkjvgel-QOP-kiq6vtud" componentType="Textarea" maxLength="255">
+            <response name="CLOWNING42"/>
             <bindingDependencies>CLOWNING42</bindingDependencies>
-            <cells type="header">
-               <cells headerCell="true">
-                  <label/>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Clowning"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Remember?"</label>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>1</value>
-                  <label>"Break the windows of the whole city"</label>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6m5n0" componentType="Dropdown">
-                  <options>
-                     <value>1</value>
-                     <label>"Jay"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"Bart"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Krusty the clown"</label>
-                  </options>
-                  <options>
-                     <value>O</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="CLOWNING11"/>
-                  <bindingDependencies>CLOWNING11</bindingDependencies>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6qatu" componentType="Textarea" maxLength="255">
-                  <response name="CLOWNING12"/>
-                  <bindingDependencies>CLOWNING12</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>2</value>
-                  <label>"Loose the violin of his daughter playing poker"</label>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6l29o" componentType="Dropdown">
-                  <options>
-                     <value>1</value>
-                     <label>"Jay"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"Bart"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Krusty the clown"</label>
-                  </options>
-                  <options>
-                     <value>O</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="CLOWNING21"/>
-                  <bindingDependencies>CLOWNING21</bindingDependencies>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6v4oe" componentType="Textarea" maxLength="255">
-                  <response name="CLOWNING22"/>
-                  <bindingDependencies>CLOWNING22</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>3</value>
-                  <label>"Kill Mr Burns"</label>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq72biw" componentType="Dropdown">
-                  <options>
-                     <value>1</value>
-                     <label>"Jay"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"Bart"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Krusty the clown"</label>
-                  </options>
-                  <options>
-                     <value>O</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="CLOWNING31"/>
-                  <bindingDependencies>CLOWNING31</bindingDependencies>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6q4zm" componentType="Textarea" maxLength="255">
-                  <response name="CLOWNING32"/>
-                  <bindingDependencies>CLOWNING32</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>4</value>
-                  <label>"Leaving a mechanical object to control the nuclear power plant"</label>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6mlan" componentType="Dropdown">
-                  <options>
-                     <value>1</value>
-                     <label>"Jay"</label>
-                  </options>
-                  <options>
-                     <value>2</value>
-                     <label>"Bart"</label>
-                  </options>
-                  <options>
-                     <value>3</value>
-                     <label>"Krusty the clown"</label>
-                  </options>
-                  <options>
-                     <value>O</value>
-                     <label>"Other"</label>
-                  </options>
-                  <response name="CLOWNING41"/>
-                  <bindingDependencies>CLOWNING41</bindingDependencies>
-               </cells>
-               <cells id="kbkjvgel-QOP-kiq6vtud" componentType="Textarea" maxLength="255">
-                  <response name="CLOWNING42"/>
-                  <bindingDependencies>CLOWNING42</bindingDependencies>
-               </cells>
-            </cells>
-         </components>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Subsequence"
                componentType="Subsequence"
                id="j6qeh91y"
                goToPage="27">
-      <label>"Transport"</label>
+      <label>
+         <value>"Transport"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
       <hierarchy>
-            <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
-            </sequence>
-            <subSequence id="j6qeh91y" page="27">
-               <label>"Transport"</label>
-            </subSequence>
-         </hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qeh91y" page="27">
+            <label>
+               <value>"Transport"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
    </components>
    <components xsi:type="Table"
                componentType="Table"
@@ -1555,204 +2278,255 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="27">
-            <label>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</label>
-            <declarations declarationType="INSTRUCTION"
+      <label>
+         <value>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="INSTRUCTION"
                     id="j6p2lwuj-d10"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Several answers possible: check off all the relevant boxes"</label>
-            </declarations>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
-               </sequence>
-               <subSequence id="j6qeh91y" page="27">
-                  <label>"Transport"</label>
-               </subSequence>
-            </hierarchy>
+         <label>
+            <value>"Several answers possible: check off all the relevant boxes"</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j4nw88h2" page="23">
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+         <subSequence id="j6qeh91y" page="27">
+            <label>
+               <value>"Transport"</value>
+               <type>VTL|MD</type>
+            </label>
+         </subSequence>
+      </hierarchy>
+      <bindingDependencies>TRAVEL11</bindingDependencies>
+      <bindingDependencies>TRAVEL12</bindingDependencies>
+      <bindingDependencies>TRAVEL13</bindingDependencies>
+      <bindingDependencies>TRAVEL14</bindingDependencies>
+      <bindingDependencies>TRAVEL15</bindingDependencies>
+      <bindingDependencies>TRAVEL16</bindingDependencies>
+      <bindingDependencies>TRAVEL21</bindingDependencies>
+      <bindingDependencies>TRAVEL22</bindingDependencies>
+      <bindingDependencies>TRAVEL23</bindingDependencies>
+      <bindingDependencies>TRAVEL24</bindingDependencies>
+      <bindingDependencies>TRAVEL25</bindingDependencies>
+      <bindingDependencies>TRAVEL26</bindingDependencies>
+      <bindingDependencies>TRAVEL31</bindingDependencies>
+      <bindingDependencies>TRAVEL32</bindingDependencies>
+      <bindingDependencies>TRAVEL33</bindingDependencies>
+      <bindingDependencies>TRAVEL34</bindingDependencies>
+      <bindingDependencies>TRAVEL35</bindingDependencies>
+      <bindingDependencies>TRAVEL36</bindingDependencies>
+      <bindingDependencies>TRAVEL41</bindingDependencies>
+      <bindingDependencies>TRAVEL42</bindingDependencies>
+      <bindingDependencies>TRAVEL43</bindingDependencies>
+      <bindingDependencies>TRAVEL44</bindingDependencies>
+      <bindingDependencies>TRAVEL45</bindingDependencies>
+      <bindingDependencies>TRAVEL46</bindingDependencies>
+      <cells type="header">
+         <cells headerCell="true">
+            <label>
+               <value/>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Brazil"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Canada"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Japan"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"France"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Other country"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Other planet"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Car"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvm4qg" componentType="CheckboxBoolean">
+            <response name="TRAVEL11"/>
             <bindingDependencies>TRAVEL11</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv8wxl" componentType="CheckboxBoolean">
+            <response name="TRAVEL12"/>
             <bindingDependencies>TRAVEL12</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvcjrn" componentType="CheckboxBoolean">
+            <response name="TRAVEL13"/>
             <bindingDependencies>TRAVEL13</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvdrv7" componentType="CheckboxBoolean">
+            <response name="TRAVEL14"/>
             <bindingDependencies>TRAVEL14</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv226h" componentType="CheckboxBoolean">
+            <response name="TRAVEL15"/>
             <bindingDependencies>TRAVEL15</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvlchm" componentType="CheckboxBoolean">
+            <response name="TRAVEL16"/>
             <bindingDependencies>TRAVEL16</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Bike"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvebem" componentType="CheckboxBoolean">
+            <response name="TRAVEL21"/>
             <bindingDependencies>TRAVEL21</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv5u0v" componentType="CheckboxBoolean">
+            <response name="TRAVEL22"/>
             <bindingDependencies>TRAVEL22</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvdarq" componentType="CheckboxBoolean">
+            <response name="TRAVEL23"/>
             <bindingDependencies>TRAVEL23</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvc8ft" componentType="CheckboxBoolean">
+            <response name="TRAVEL24"/>
             <bindingDependencies>TRAVEL24</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvc2li" componentType="CheckboxBoolean">
+            <response name="TRAVEL25"/>
             <bindingDependencies>TRAVEL25</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvh5fm" componentType="CheckboxBoolean">
+            <response name="TRAVEL26"/>
             <bindingDependencies>TRAVEL26</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Skateboard"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv62xx" componentType="CheckboxBoolean">
+            <response name="TRAVEL31"/>
             <bindingDependencies>TRAVEL31</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvbiyv" componentType="CheckboxBoolean">
+            <response name="TRAVEL32"/>
             <bindingDependencies>TRAVEL32</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvcmjn" componentType="CheckboxBoolean">
+            <response name="TRAVEL33"/>
             <bindingDependencies>TRAVEL33</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvkci5" componentType="CheckboxBoolean">
+            <response name="TRAVEL34"/>
             <bindingDependencies>TRAVEL34</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewveam7" componentType="CheckboxBoolean">
+            <response name="TRAVEL35"/>
             <bindingDependencies>TRAVEL35</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewva2r8" componentType="CheckboxBoolean">
+            <response name="TRAVEL36"/>
             <bindingDependencies>TRAVEL36</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>4</value>
+            <label>
+               <value>"Plane"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvjcck" componentType="CheckboxBoolean">
+            <response name="TRAVEL41"/>
             <bindingDependencies>TRAVEL41</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv91bq" componentType="CheckboxBoolean">
+            <response name="TRAVEL42"/>
             <bindingDependencies>TRAVEL42</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewvf47u" componentType="CheckboxBoolean">
+            <response name="TRAVEL43"/>
             <bindingDependencies>TRAVEL43</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewv5hsr" componentType="CheckboxBoolean">
+            <response name="TRAVEL44"/>
             <bindingDependencies>TRAVEL44</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewva3p8" componentType="CheckboxBoolean">
+            <response name="TRAVEL45"/>
             <bindingDependencies>TRAVEL45</bindingDependencies>
+         </cells>
+         <cells id="j6p2lwuj-QOP-kewve0rb" componentType="CheckboxBoolean">
+            <response name="TRAVEL46"/>
             <bindingDependencies>TRAVEL46</bindingDependencies>
-            <cells type="header">
-               <cells headerCell="true">
-                  <label/>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Brazil"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Canada"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Japan"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"France"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Other country"</label>
-               </cells>
-               <cells headerCell="true">
-                  <label>"Other planet"</label>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>1</value>
-                  <label>"Car"</label>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvm4qg" componentType="CheckboxBoolean">
-                  <response name="TRAVEL11"/>
-                  <bindingDependencies>TRAVEL11</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv8wxl" componentType="CheckboxBoolean">
-                  <response name="TRAVEL12"/>
-                  <bindingDependencies>TRAVEL12</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvcjrn" componentType="CheckboxBoolean">
-                  <response name="TRAVEL13"/>
-                  <bindingDependencies>TRAVEL13</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvdrv7" componentType="CheckboxBoolean">
-                  <response name="TRAVEL14"/>
-                  <bindingDependencies>TRAVEL14</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv226h" componentType="CheckboxBoolean">
-                  <response name="TRAVEL15"/>
-                  <bindingDependencies>TRAVEL15</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvlchm" componentType="CheckboxBoolean">
-                  <response name="TRAVEL16"/>
-                  <bindingDependencies>TRAVEL16</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>2</value>
-                  <label>"Bike"</label>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvebem" componentType="CheckboxBoolean">
-                  <response name="TRAVEL21"/>
-                  <bindingDependencies>TRAVEL21</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv5u0v" componentType="CheckboxBoolean">
-                  <response name="TRAVEL22"/>
-                  <bindingDependencies>TRAVEL22</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvdarq" componentType="CheckboxBoolean">
-                  <response name="TRAVEL23"/>
-                  <bindingDependencies>TRAVEL23</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvc8ft" componentType="CheckboxBoolean">
-                  <response name="TRAVEL24"/>
-                  <bindingDependencies>TRAVEL24</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvc2li" componentType="CheckboxBoolean">
-                  <response name="TRAVEL25"/>
-                  <bindingDependencies>TRAVEL25</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvh5fm" componentType="CheckboxBoolean">
-                  <response name="TRAVEL26"/>
-                  <bindingDependencies>TRAVEL26</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>3</value>
-                  <label>"Skateboard"</label>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv62xx" componentType="CheckboxBoolean">
-                  <response name="TRAVEL31"/>
-                  <bindingDependencies>TRAVEL31</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvbiyv" componentType="CheckboxBoolean">
-                  <response name="TRAVEL32"/>
-                  <bindingDependencies>TRAVEL32</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvcmjn" componentType="CheckboxBoolean">
-                  <response name="TRAVEL33"/>
-                  <bindingDependencies>TRAVEL33</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvkci5" componentType="CheckboxBoolean">
-                  <response name="TRAVEL34"/>
-                  <bindingDependencies>TRAVEL34</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewveam7" componentType="CheckboxBoolean">
-                  <response name="TRAVEL35"/>
-                  <bindingDependencies>TRAVEL35</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewva2r8" componentType="CheckboxBoolean">
-                  <response name="TRAVEL36"/>
-                  <bindingDependencies>TRAVEL36</bindingDependencies>
-               </cells>
-            </cells>
-            <cells type="line">
-               <cells>
-                  <value>4</value>
-                  <label>"Plane"</label>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvjcck" componentType="CheckboxBoolean">
-                  <response name="TRAVEL41"/>
-                  <bindingDependencies>TRAVEL41</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv91bq" componentType="CheckboxBoolean">
-                  <response name="TRAVEL42"/>
-                  <bindingDependencies>TRAVEL42</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewvf47u" componentType="CheckboxBoolean">
-                  <response name="TRAVEL43"/>
-                  <bindingDependencies>TRAVEL43</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewv5hsr" componentType="CheckboxBoolean">
-                  <response name="TRAVEL44"/>
-                  <bindingDependencies>TRAVEL44</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewva3p8" componentType="CheckboxBoolean">
-                  <response name="TRAVEL45"/>
-                  <bindingDependencies>TRAVEL45</bindingDependencies>
-               </cells>
-               <cells id="j6p2lwuj-QOP-kewve0rb" componentType="CheckboxBoolean">
-                  <response name="TRAVEL46"/>
-                  <bindingDependencies>TRAVEL46</bindingDependencies>
-               </cells>
-            </cells>
-         </components>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6qfx9qe"
                page="28">
-      <label>"V - Favourite characters (dynamic table)"</label>
+      <label>
+         <value>"V - Favourite characters (dynamic table)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qfx9qe" page="28">
-            <label>"V - Favourite characters (dynamic table)"</label>
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -1762,651 +2536,876 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="29">
-         <label>"➡ 1. Please, complete the following grid with your favourite characters"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>FAVOURITE_CHAR1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_1_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_1_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_2_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_2_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_3_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_3_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_4_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_4_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_5_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_5_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_6_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_6_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_7_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_7_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_8_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_8_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_9_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_9_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
-         <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
-         <lines min="1" max="10"/>
-         <cells type="header">
-            <cells headerCell="true">
-               <label>"Name"</label>
-            </cells>
-            <cells headerCell="true">
-               <label>"Age"</label>
-            </cells>
-            <cells headerCell="true">
-               <label>"Member of the Simpsons family"</label>
-            </cells>
+      <label>
+         <value>"➡ 1. Please, complete the following grid with your favourite characters"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qfx9qe" page="28">
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>FAVOURITE_CHAR1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_1_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_1_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_2_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_2_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_3_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_3_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_4_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_4_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_5_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_5_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_6_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_6_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_7_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_7_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_8_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_8_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_9_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_9_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
+      <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
+      <lines min="1" max="10"/>
+      <cells type="header">
+         <cells headerCell="true">
+            <label>
+               <value>"Name"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_1_1"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR1_1_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_1_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_1_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_1_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_1_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_1_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_1_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
-            </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Age"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_2_1"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR1_2_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_2_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_2_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_2_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_2_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_2_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_2_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
-            </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Member of the Simpsons family"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_3_1"
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_1_1"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_3_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_3_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_3_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_3_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_3_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_3_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_3_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR1_1_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_1_1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_4_1"
+         <cells id="j6qg8rc6-QOP-kiq7kny3_1_2"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_4_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_4_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_4_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_4_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_4_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_4_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_4_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR2_1_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_1_2</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_5_1"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR1_5_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_5_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_5_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_5_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_5_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_5_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_5_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
-            </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_1_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_1_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_6_1"
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_2_1"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_6_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_6_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_6_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_6_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_6_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_6_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_6_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR1_2_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_2_1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_7_1"
+         <cells id="j6qg8rc6-QOP-kiq7kny3_2_2"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_7_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_7_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_7_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_7_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_7_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_7_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_7_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR2_2_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_2_2</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_8_1"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR1_8_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_8_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_8_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_8_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_8_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_8_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_8_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
-            </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_2_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_2_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_9_1"
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_3_1"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_9_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_9_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_9_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_9_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_9_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_9_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_9_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR1_3_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_3_1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells id="j6qg8rc6-QOP-kiq7p16z_10_1"
+         <cells id="j6qg8rc6-QOP-kiq7kny3_3_2"
                 componentType="Textarea"
                 maxLength="255">
-               <response name="FAVOURITE_CHAR1_10_1"/>
-               <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7kny3_10_2"
-                componentType="Textarea"
-                maxLength="255">
-               <response name="FAVOURITE_CHAR2_10_2"/>
-               <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
-            </cells>
-            <cells id="j6qg8rc6-QOP-kiq7lffy_10_3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Yes"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"No"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Other"</label>
-               </options>
-               <response name="FAVOURITE_CHAR3_10_3"/>
-               <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
-            </cells>
+            <response name="FAVOURITE_CHAR2_3_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_3_2</bindingDependencies>
          </cells>
-      </components>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_3_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_3_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_4_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_4_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_4_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_4_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_4_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_4_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_4_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_4_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_5_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_5_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_5_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_5_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_5_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_5_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_5_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_5_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_6_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_6_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_6_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_6_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_6_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_6_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_6_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_6_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_7_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_7_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_7_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_7_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_7_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_7_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_7_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_7_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_8_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_8_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_8_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_8_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_8_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_8_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_8_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_8_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_9_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_9_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_9_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_9_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_9_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_9_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_9_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_9_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells id="j6qg8rc6-QOP-kiq7p16z_10_1"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR1_10_1"/>
+            <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7kny3_10_2"
+                componentType="Textarea"
+                maxLength="255">
+            <response name="FAVOURITE_CHAR2_10_2"/>
+            <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
+         </cells>
+         <cells id="j6qg8rc6-QOP-kiq7lffy_10_3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FAVOURITE_CHAR3_10_3"/>
+            <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="jvxux0mi"
                positioning="HORIZONTAL"
                mandatory="false"
                page="30">
-         <label>"➡ 2. How has your feeling about the following characters evolved over time?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>FEELCHAREV1</bindingDependencies>
-         <bindingDependencies>FEELCHAREV2</bindingDependencies>
-         <bindingDependencies>FEELCHAREV3</bindingDependencies>
-         <bindingDependencies>FEELCHAREV4</bindingDependencies>
-         <cells type="line">
-            <cells>
+      <label>
+         <value>"➡ 2. How has your feeling about the following characters evolved over time?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qfx9qe" page="28">
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>FEELCHAREV1</bindingDependencies>
+      <bindingDependencies>FEELCHAREV2</bindingDependencies>
+      <bindingDependencies>FEELCHAREV3</bindingDependencies>
+      <bindingDependencies>FEELCHAREV4</bindingDependencies>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Jay"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxux0mi-QOP-kiq76emy" componentType="CheckboxOne">
+            <options>
                <value>1</value>
-               <label>"Jay"</label>
-            </cells>
-            <cells id="jvxux0mi-QOP-kiq76emy" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Up"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Down"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Steady"</label>
-               </options>
-               <response name="FEELCHAREV1"/>
-               <bindingDependencies>FEELCHAREV1</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Up"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>2</value>
-               <label>"Bart"</label>
-            </cells>
-            <cells id="jvxux0mi-QOP-kiq6zv60" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Up"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Down"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Steady"</label>
-               </options>
-               <response name="FEELCHAREV2"/>
-               <bindingDependencies>FEELCHAREV2</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Down"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>3</value>
-               <label>"Krusty the clown"</label>
-            </cells>
-            <cells id="jvxux0mi-QOP-kiq7bgk3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Up"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Down"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Steady"</label>
-               </options>
-               <response name="FEELCHAREV3"/>
-               <bindingDependencies>FEELCHAREV3</bindingDependencies>
-            </cells>
+               <label>
+                  <value>"Steady"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FEELCHAREV1"/>
+            <bindingDependencies>FEELCHAREV1</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>O</value>
-               <label>"Other"</label>
-            </cells>
-            <cells id="jvxux0mi-QOP-kiq6ync3" componentType="CheckboxOne">
-               <options>
-                  <value>1</value>
-                  <label>"Up"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Down"</label>
-               </options>
-               <options>
-                  <value>3</value>
-                  <label>"Steady"</label>
-               </options>
-               <response name="FEELCHAREV4"/>
-               <bindingDependencies>FEELCHAREV4</bindingDependencies>
-            </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Bart"</value>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-      </components>
+         <cells id="jvxux0mi-QOP-kiq6zv60" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Up"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Down"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Steady"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FEELCHAREV2"/>
+            <bindingDependencies>FEELCHAREV2</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Krusty the clown"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxux0mi-QOP-kiq7bgk3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Up"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Down"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Steady"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FEELCHAREV3"/>
+            <bindingDependencies>FEELCHAREV3</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>O</value>
+            <label>
+               <value>"Other"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxux0mi-QOP-kiq6ync3" componentType="CheckboxOne">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Up"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Down"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>3</value>
+               <label>
+                  <value>"Steady"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="FEELCHAREV4"/>
+            <bindingDependencies>FEELCHAREV4</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Table"
                componentType="Table"
                id="jvxwy68n"
                positioning="HORIZONTAL"
                mandatory="false"
                page="31">
-         <label>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>LEAVDURATION11</bindingDependencies>
-         <bindingDependencies>LEAVDURATION12</bindingDependencies>
-         <bindingDependencies>LEAVDURATION21</bindingDependencies>
-         <bindingDependencies>LEAVDURATION22</bindingDependencies>
-         <bindingDependencies>LEAVDURATION31</bindingDependencies>
-         <bindingDependencies>LEAVDURATION32</bindingDependencies>
-         <bindingDependencies>LEAVDURATION41</bindingDependencies>
-         <bindingDependencies>LEAVDURATION42</bindingDependencies>
-         <bindingDependencies>LEAVDURATION51</bindingDependencies>
-         <bindingDependencies>LEAVDURATION52</bindingDependencies>
-         <cells type="header">
-            <cells headerCell="true">
-               <label/>
-            </cells>
-            <cells headerCell="true">
-               <label>"Days"</label>
-            </cells>
-            <cells headerCell="true">
-               <label>"Unit"</label>
-            </cells>
+      <label>
+         <value>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6qfx9qe" page="28">
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>LEAVDURATION11</bindingDependencies>
+      <bindingDependencies>LEAVDURATION12</bindingDependencies>
+      <bindingDependencies>LEAVDURATION21</bindingDependencies>
+      <bindingDependencies>LEAVDURATION22</bindingDependencies>
+      <bindingDependencies>LEAVDURATION31</bindingDependencies>
+      <bindingDependencies>LEAVDURATION32</bindingDependencies>
+      <bindingDependencies>LEAVDURATION41</bindingDependencies>
+      <bindingDependencies>LEAVDURATION42</bindingDependencies>
+      <bindingDependencies>LEAVDURATION51</bindingDependencies>
+      <bindingDependencies>LEAVDURATION52</bindingDependencies>
+      <cells type="header">
+         <cells headerCell="true">
+            <label>
+               <value/>
+               <type>VTL|MD</type>
+            </label>
          </cells>
-         <cells type="line">
-            <cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Days"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells headerCell="true">
+            <label>
+               <value>"Unit"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>1</value>
+            <label>
+               <value>"Leave with pay"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewv511d"
+                componentType="InputNumber"
+                min="0"
+                max="365"
+                decimals="0">
+            <response name="LEAVDURATION11"/>
+            <bindingDependencies>LEAVDURATION11</bindingDependencies>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewv20qg" componentType="Dropdown">
+            <options>
                <value>1</value>
-               <label>"Leave with pay"</label>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv511d"
-                componentType="InputNumber"
-                min="0"
-                max="365"
-                decimals="0">
-               <response name="LEAVDURATION11"/>
-               <bindingDependencies>LEAVDURATION11</bindingDependencies>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv20qg" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Working Days"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Calendar days"</label>
-               </options>
-               <response name="LEAVDURATION12"/>
-               <bindingDependencies>LEAVDURATION12</bindingDependencies>
-            </cells>
-         </cells>
-         <cells type="line">
-            <cells>
+               <label>
+                  <value>"Working Days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
                <value>2</value>
-               <label>"Public holiday"</label>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv67nj"
+               <label>
+                  <value>"Calendar days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LEAVDURATION12"/>
+            <bindingDependencies>LEAVDURATION12</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>2</value>
+            <label>
+               <value>"Public holiday"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewv67nj"
                 componentType="InputNumber"
                 min="0"
                 max="365"
                 decimals="0">
-               <response name="LEAVDURATION21"/>
-               <bindingDependencies>LEAVDURATION21</bindingDependencies>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewvizdm" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Working Days"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Calendar days"</label>
-               </options>
-               <response name="LEAVDURATION22"/>
-               <bindingDependencies>LEAVDURATION22</bindingDependencies>
-            </cells>
+            <response name="LEAVDURATION21"/>
+            <bindingDependencies>LEAVDURATION21</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>3</value>
-               <label>"Sick leave"</label>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv23wm"
+         <cells id="jvxwy68n-QOP-kewvizdm" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Working Days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Calendar days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LEAVDURATION22"/>
+            <bindingDependencies>LEAVDURATION22</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>3</value>
+            <label>
+               <value>"Sick leave"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewv23wm"
                 componentType="InputNumber"
                 min="0"
                 max="365"
                 decimals="0">
-               <response name="LEAVDURATION31"/>
-               <bindingDependencies>LEAVDURATION31</bindingDependencies>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv9jcl" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Working Days"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Calendar days"</label>
-               </options>
-               <response name="LEAVDURATION32"/>
-               <bindingDependencies>LEAVDURATION32</bindingDependencies>
-            </cells>
+            <response name="LEAVDURATION31"/>
+            <bindingDependencies>LEAVDURATION31</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>4</value>
-               <label>"Maternity/paternity leave"</label>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewv2jks"
+         <cells id="jvxwy68n-QOP-kewv9jcl" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Working Days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Calendar days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LEAVDURATION32"/>
+            <bindingDependencies>LEAVDURATION32</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>4</value>
+            <label>
+               <value>"Maternity/paternity leave"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewv2jks"
                 componentType="InputNumber"
                 min="0"
                 max="365"
                 decimals="0">
-               <response name="LEAVDURATION41"/>
-               <bindingDependencies>LEAVDURATION41</bindingDependencies>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewvf0gf" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Working Days"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Calendar days"</label>
-               </options>
-               <response name="LEAVDURATION42"/>
-               <bindingDependencies>LEAVDURATION42</bindingDependencies>
-            </cells>
+            <response name="LEAVDURATION41"/>
+            <bindingDependencies>LEAVDURATION41</bindingDependencies>
          </cells>
-         <cells type="line">
-            <cells>
-               <value>5</value>
-               <label>"Other type"</label>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewvl896"
+         <cells id="jvxwy68n-QOP-kewvf0gf" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Working Days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Calendar days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LEAVDURATION42"/>
+            <bindingDependencies>LEAVDURATION42</bindingDependencies>
+         </cells>
+      </cells>
+      <cells type="line">
+         <cells>
+            <value>5</value>
+            <label>
+               <value>"Other type"</value>
+               <type>VTL|MD</type>
+            </label>
+         </cells>
+         <cells id="jvxwy68n-QOP-kewvl896"
                 componentType="InputNumber"
                 min="0"
                 max="365"
                 decimals="0">
-               <response name="LEAVDURATION51"/>
-               <bindingDependencies>LEAVDURATION51</bindingDependencies>
-            </cells>
-            <cells id="jvxwy68n-QOP-kewvalmd" componentType="Dropdown">
-               <options>
-                  <value>1</value>
-                  <label>"Working Days"</label>
-               </options>
-               <options>
-                  <value>2</value>
-                  <label>"Calendar days"</label>
-               </options>
-               <response name="LEAVDURATION52"/>
-               <bindingDependencies>LEAVDURATION52</bindingDependencies>
-            </cells>
+            <response name="LEAVDURATION51"/>
+            <bindingDependencies>LEAVDURATION51</bindingDependencies>
          </cells>
-      </components>
+         <cells id="jvxwy68n-QOP-kewvalmd" componentType="Dropdown">
+            <options>
+               <value>1</value>
+               <label>
+                  <value>"Working Days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>2</value>
+               <label>
+                  <value>"Calendar days"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="LEAVDURATION52"/>
+            <bindingDependencies>LEAVDURATION52</bindingDependencies>
+         </cells>
+      </cells>
+   </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="kiq5mr0b"
                page="32">
-      <label>"VI - Favourite characters (Loop)"</label>
+      <label>
+         <value>"VI - Favourite characters (Loop)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="kiq5mr0b" page="32">
-            <label>"VI - Favourite characters (Loop)"</label>
+            <label>
+               <value>"VI - Favourite characters (Loop)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -2418,54 +3417,75 @@
                max="20"
                decimals="0"
                page="33">
-         <label>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</label>
-         <conditionFilter>
-            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-            <bindingDependencies>READY</bindingDependencies>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>NB_CHAR</bindingDependencies>
-         <response name="NB_CHAR"/>
-      </components>
+      <label>
+         <value>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="kiq5mr0b" page="32">
+            <label>
+               <value>"VI - Favourite characters (Loop)"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>NB_CHAR</bindingDependencies>
+      <response name="NB_CHAR"/>
+   </components>
    <components xsi:type="Loop"
                componentType="Loop"
                id="kiq7bjam"
                page="34"
                paginatedLoop="false">
-         <label>"Add a character"</label>
+      <label>
+         <value>"Add a character"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <bindingDependencies>READY</bindingDependencies>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="kiq5mr0b" page="32">
+            <label>
+               <value>"VI - Favourite characters (Loop)"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>NAME_CHAR</bindingDependencies>
+      <bindingDependencies>AGE_CHAR</bindingDependencies>
+      <components xsi:type="Subsequence"
+                  componentType="Subsequence"
+                  id="kiq5u8d5"
+                  page="34"
+                  goToPage="34">
+         <label>
+            <value>"Description of each character"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
+            <subSequence id="kiq5u8d5" page="34">
+               <label>
+                  <value>"Description of each character"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </subSequence>
          </hierarchy>
-         <bindingDependencies>NAME_CHAR</bindingDependencies>
-         <bindingDependencies>AGE_CHAR</bindingDependencies>
-         <components xsi:type="Subsequence"
-                  componentType="Subsequence"
-                  id="kiq5u8d5"
-                  page="34"
-                  goToPage="34">
-         <label>"Description of each character"</label>
-         <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-         <hierarchy>
-               <sequence id="kiq5mr0b" page="32">
-                  <label>"VI - Favourite characters (Loop)"</label>
-               </sequence>
-               <subSequence id="kiq5u8d5" page="34">
-                  <label>"Description of each character"</label>
-               </subSequence>
-            </hierarchy>
       </components>
       <components xsi:type="Input"
                   componentType="Input"
@@ -2473,22 +3493,31 @@
                   maxLength="30"
                   mandatory="false"
                   page="34">
-               <label>"➡ 2. What is the first name of this character?"</label>
-               <conditionFilter>
-                  <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-                  <bindingDependencies>READY</bindingDependencies>
-               </conditionFilter>
-               <hierarchy>
-                  <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
-                  </sequence>
-                  <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
-                  </subSequence>
-               </hierarchy>
-               <bindingDependencies>NAME_CHAR</bindingDependencies>
-               <response name="NAME_CHAR"/>
-            </components>
+         <label>
+            <value>"➡ 2. What is the first name of this character?"</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <bindingDependencies>READY</bindingDependencies>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="kiq5mr0b" page="32">
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+            <subSequence id="kiq5u8d5" page="34">
+               <label>
+                  <value>"Description of each character"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </subSequence>
+         </hierarchy>
+         <bindingDependencies>NAME_CHAR</bindingDependencies>
+         <response name="NAME_CHAR"/>
+      </components>
       <components xsi:type="InputNumber"
                   componentType="InputNumber"
                   id="kiq5r8wu"
@@ -2497,23 +3526,32 @@
                   max="120"
                   decimals="0"
                   page="34">
-               <label>"➡ 3. How old is this character in the first episode of the Simpsons family?"</label>
-               <conditionFilter>
-                  <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-                  <bindingDependencies>READY</bindingDependencies>
-               </conditionFilter>
-               <hierarchy>
-                  <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
-                  </sequence>
-                  <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
-                  </subSequence>
-               </hierarchy>
-               <bindingDependencies>AGE_CHAR</bindingDependencies>
-               <response name="AGE_CHAR"/>
-            </components>
+         <label>
+            <value>"➡ 3. How old is this character in the first episode of the Simpsons family?"</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <bindingDependencies>READY</bindingDependencies>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="kiq5mr0b" page="32">
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+            <subSequence id="kiq5u8d5" page="34">
+               <label>
+                  <value>"Description of each character"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </subSequence>
+         </hierarchy>
+         <bindingDependencies>AGE_CHAR</bindingDependencies>
+         <response name="AGE_CHAR"/>
       </components>
+   </components>
    <components xsi:type="Loop"
                componentType="Loop"
                id="kiq7cbgo"
@@ -2535,14 +3573,20 @@
                   componentType="Sequence"
                   id="kiq5xw5p"
                   page="35.1">
-         <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+         <label>
+            <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5xw5p" page="35.1">
-               <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+               <label>
+                  <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2552,60 +3596,84 @@
                   id="kiq65x3c"
                   mandatory="false"
                   page="35.2">
-            <label>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
-               </sequence>
-            </hierarchy>
-            <bindingDependencies>NAME_CHAR</bindingDependencies>
-            <bindingDependencies>FAVCHAR</bindingDependencies>
-            <options>
-               <value>1</value>
-               <label>"Yes"</label>
-            </options>
-            <options>
-               <value>0</value>
-               <label>"No"</label>
-            </options>
-            <response name="FAVCHAR"/>
-         </components>
+         <label>
+            <value>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <bindingDependencies>READY</bindingDependencies>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="kiq5xw5p" page="35.1">
+               <label>
+                  <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>NAME_CHAR</bindingDependencies>
+         <bindingDependencies>FAVCHAR</bindingDependencies>
+         <options>
+            <value>1</value>
+            <label>
+               <value>"Yes"</value>
+               <type>VTL|MD</type>
+            </label>
+         </options>
+         <options>
+            <value>0</value>
+            <label>
+               <value>"No"</value>
+               <type>VTL|MD</type>
+            </label>
+         </options>
+         <response name="FAVCHAR"/>
+      </components>
       <components xsi:type="Textarea"
                   componentType="Textarea"
                   id="kiq651zv"
                   maxLength="255"
                   mandatory="false"
                   page="35.3">
-            <label>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</label>
-            <conditionFilter>
-               <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
-               <bindingDependencies>READY</bindingDependencies>
-            </conditionFilter>
-            <hierarchy>
-               <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
-               </sequence>
-            </hierarchy>
-            <bindingDependencies>NAME_CHAR</bindingDependencies>
-            <bindingDependencies>MEMORY_CHAR</bindingDependencies>
-            <response name="MEMORY_CHAR"/>
-         </components>
+         <label>
+            <value>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <bindingDependencies>READY</bindingDependencies>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="kiq5xw5p" page="35.1">
+               <label>
+                  <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>NAME_CHAR</bindingDependencies>
+         <bindingDependencies>MEMORY_CHAR</bindingDependencies>
+         <response name="MEMORY_CHAR"/>
+      </components>
    </components>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6z12s2d"
                page="36">
-      <label>"VIII - Comment"</label>
+      <label>
+         <value>"VIII - Comment"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
-            <label>"VIII - Comment"</label>
+            <label>
+               <value>"VIII - Comment"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -2615,18 +3683,24 @@
                maxLength="255"
                mandatory="false"
                page="37">
-         <label>"➡ 1. Do you have any comment about the survey?"</label>
-         <conditionFilter>
-            <value>true</value>
-         </conditionFilter>
-         <hierarchy>
-            <sequence id="j6z12s2d" page="36">
-               <label>"VIII - Comment"</label>
-            </sequence>
-         </hierarchy>
-         <bindingDependencies>SURVEY_COMMENT</bindingDependencies>
-         <response name="SURVEY_COMMENT"/>
-      </components>
+      <label>
+         <value>"➡ 1. Do you have any comment about the survey?"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="j6z12s2d" page="36">
+            <label>
+               <value>"VIII - Comment"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>SURVEY_COMMENT</bindingDependencies>
+      <response name="SURVEY_COMMENT"/>
+   </components>
    <variables variableType="COLLECTED" xsi:type="VariableType">
       <name>FAVOURITE_CHAR1_1_1</name>
       <componentRef>j6qg8rc6</componentRef>

--- a/src/test/resources/dummy/form_flat.xml
+++ b/src/test/resources/dummy/form_flat.xml
@@ -28,6 +28,7 @@
       </declarations>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -50,6 +51,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -81,6 +83,7 @@
       </declarations>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -104,6 +107,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -124,6 +128,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -153,6 +158,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -186,6 +192,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -226,6 +233,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -266,6 +274,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -307,6 +316,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -341,6 +351,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -375,6 +386,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -409,6 +421,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -443,6 +456,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -477,6 +491,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -515,6 +530,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -545,6 +561,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -598,6 +615,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -650,6 +668,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -764,6 +783,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -793,6 +813,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -856,6 +877,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -991,6 +1013,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1126,6 +1149,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1392,6 +1416,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1413,6 +1438,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1442,6 +1468,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1649,6 +1676,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1991,6 +2019,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2020,6 +2049,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2255,6 +2285,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2292,6 +2323,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2519,6 +2551,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2542,6 +2575,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2585,7 +2619,16 @@
       <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
       <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
       <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
-      <lines min="1" max="10"/>
+      <lines>
+         <min>
+            <value>1</value>
+            <type>VTL|MD</type>
+         </min>
+         <max>
+            <value>10</value>
+            <type>VTL|MD</type>
+         </max>
+      </lines>
       <cells type="header">
          <cells headerCell="true">
             <label>
@@ -3009,6 +3052,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3172,6 +3216,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3398,6 +3443,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3423,6 +3469,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3447,6 +3494,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3470,6 +3518,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3499,6 +3548,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3532,6 +3582,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3556,12 +3607,16 @@
                componentType="Loop"
                id="kiq7cbgo"
                depth="1"
-               iterations="count(NAME_CHAR)"
                page="35"
                maxPage="3"
                paginatedLoop="true">
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -3579,6 +3634,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3602,6 +3658,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3642,6 +3699,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3667,6 +3725,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
@@ -3689,6 +3748,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">

--- a/src/test/resources/examples/xmlf-2-jsonf/out.json
+++ b/src/test/resources/examples/xmlf-2-jsonf/out.json
@@ -2,44 +2,56 @@
   { "id" : "i6vwi2506qf2mms",
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
-    "lunaticModelVersion" : "2.1.2",
-    "generatingDate" : "28-06-2021 17:07:23",
+    "lunaticModelVersion" : "2.2.11",
+    "generatingDate" : "11-03-2022 14:52:01",
     "pagination" : "question",
     "maxPage" : "37",
-    "label" : "Questionnaire SIMPSONS 20201215",
+    "label" : 
+    { "value" : "Questionnaire SIMPSONS 20201215",
+      "type" : "VTL|MD" },
     "components" : 
     [ 
       { "id" : "j6p0ti5h",
         "componentType" : "Sequence",
         "page" : "1",
-        "label" : "\"I - Introduction\"",
+        "label" : 
+        { "value" : "\"I - Introduction\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p0ti5h-d1",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"" } ],
+            "label" : 
+            { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p3dkx6",
         "componentType" : "Textarea",
         "mandatory" : true,
         "page" : "2",
         "maxLength" : 500,
-        "label" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "COMMENT" ],
         "response" : 
@@ -49,20 +61,26 @@
         "componentType" : "CheckboxBoolean",
         "mandatory" : false,
         "page" : "3",
-        "label" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+        "label" : 
+        { "value" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p0np9q-kir6xl1e",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"If not, this is unfortunately the end of this questionnaire.\"" } ],
+            "label" : 
+            { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "READY" ],
         "response" : 
@@ -72,19 +90,25 @@
         "componentType" : "FilterDescription",
         "page" : "3",
         "filterDescription" : false,
-        "label" : "\"If you are not ready, please go to the end of the questionnaire\"",
+        "label" : 
+        { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p0s7o5",
         "componentType" : "Subsequence",
         "goToPage" : "4",
-        "label" : "\"General knowledge of the series\"",
+        "label" : 
+        { "value" : "\"General knowledge of the series\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -93,18 +117,24 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j3343qhx",
         "componentType" : "Input",
         "mandatory" : false,
         "page" : "4",
         "maxLength" : 30,
-        "label" : "\"➡ 3. Who is the producer?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Who is the producer?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -113,11 +143,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PRODUCER" ],
         "response" : 
@@ -130,7 +164,9 @@
         "min" : 0,
         "max" : 99,
         "decimals" : 0,
-        "label" : "\"➡ 4. What is the current season number?\"",
+        "label" : 
+        { "value" : "\"➡ 4. What is the current season number?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -139,11 +175,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "SEASON_NUMBER" ],
         "response" : 
@@ -155,13 +195,17 @@
         "page" : "6",
         "min" : "1900-01-01",
         "max" : "format-date(current-date(),'[Y0001]-[M01]-[D01]')",
-        "label" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+        "label" : 
+        { "value" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "kiq71eoi-kiq7dsy2",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY-MM-DD format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY-MM-DD format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -170,11 +214,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEFIRST" ],
         "dateFormat" : "YYYY-MM-DD",
@@ -186,13 +234,17 @@
         "mandatory" : false,
         "page" : "7",
         "min" : "1980-05",
-        "label" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+        "label" : 
+        { "value" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "k5nvty2o-k5nvxld8",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY-MM format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY-MM format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -201,11 +253,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEYYYYMM" ],
         "dateFormat" : "YYYY-MM",
@@ -218,13 +274,17 @@
         "page" : "8",
         "min" : "1900",
         "max" : "year-from-date(current-date())",
-        "label" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+        "label" : 
+        { "value" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "k5nw1fir-k5nvmx3n",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -233,11 +293,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEYYYY" ],
         "dateFormat" : "YYYY",
@@ -251,7 +315,9 @@
         "min" : 0,
         "max" : 70,
         "decimals" : 2,
-        "label" : "\"➡ 8. How long does an episode last?\"",
+        "label" : 
+        { "value" : "\"➡ 8. How long does an episode last?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -260,11 +326,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONH" ],
         "unit" : "heures",
@@ -278,7 +348,9 @@
         "min" : 0,
         "max" : 366,
         "decimals" : 1,
-        "label" : "\"➡ 9. How long does it take to write a new episode?\"",
+        "label" : 
+        { "value" : "\"➡ 9. How long does it take to write a new episode?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -287,11 +359,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIOND" ],
         "unit" : "jours",
@@ -305,7 +381,9 @@
         "min" : 0,
         "max" : 12,
         "decimals" : 0,
-        "label" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+        "label" : 
+        { "value" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -314,11 +392,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONM" ],
         "unit" : "mois",
@@ -332,7 +414,9 @@
         "min" : 0,
         "max" : 100,
         "decimals" : 0,
-        "label" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+        "label" : 
+        { "value" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -341,11 +425,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONY" ],
         "unit" : "années",
@@ -359,7 +447,9 @@
         "min" : 0,
         "max" : 99,
         "decimals" : 1,
-        "label" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+        "label" : 
+        { "value" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -368,11 +458,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "AUDIENCE_SHARE" ],
         "unit" : "%",
@@ -382,13 +476,17 @@
       { "id" : "j3341528",
         "componentType" : "Sequence",
         "page" : "14",
-        "label" : "\"II - Simpsons’ city\"",
+        "label" : 
+        { "value" : "\"II - Simpsons’ city\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j3341528-d2",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"This module asks about your general knowledge of the Simpsons city\"" } ],
+            "label" : 
+            { "value" : "\"This module asks about your general knowledge of the Simpsons city\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -397,19 +495,25 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j3343clt",
         "componentType" : "Radio",
         "mandatory" : true,
         "page" : "15",
-        "label" : "\"➡ 1. In which city do the Simpsons reside?\"",
+        "label" : 
+        { "value" : "\"➡ 1. In which city do the Simpsons reside?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j3343clt-d3",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"One possible answer\"" } ],
+            "label" : 
+            { "value" : "\"One possible answer\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -418,19 +522,27 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "CITY" ],
         "options" : 
         [ 
           { "value" : "00001",
-            "label" : "\"Springfield\"" },
+            "label" : 
+            { "value" : "\"Springfield\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "00002",
-            "label" : "\"Shelbyville\"" },
+            "label" : 
+            { "value" : "\"Shelbyville\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "03",
-            "label" : "\"Seinfeld\"" } ],
+            "label" : 
+            { "value" : "\"Seinfeld\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "CITY" } },
       
@@ -438,13 +550,17 @@
         "componentType" : "CheckboxOne",
         "mandatory" : false,
         "page" : "16",
-        "label" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+        "label" : 
+        { "value" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6qdfhvw-d4",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Only one possible answer\"" } ],
+            "label" : 
+            { "value" : "\"Only one possible answer\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -453,22 +569,32 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "MAYOR" ],
         "options" : 
         [ 
           { "value" : "1",
-            "label" : "\"Constance Harm\"" },
+            "label" : 
+            { "value" : "\"Constance Harm\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "2",
-            "label" : "\"Timothy Lovejoy\"" },
+            "label" : 
+            { "value" : "\"Timothy Lovejoy\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "3",
-            "label" : "\"Joe Quimby\"" },
+            "label" : 
+            { "value" : "\"Joe Quimby\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "OT",
-            "label" : "\"Other name\"" } ],
+            "label" : 
+            { "value" : "\"Other name\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "MAYOR" } },
       
@@ -476,7 +602,9 @@
         "componentType" : "Dropdown",
         "mandatory" : false,
         "page" : "17",
-        "label" : "\"➡ 3. In which state do The Simpsons reside?\"",
+        "label" : 
+        { "value" : "\"➡ 3. In which state do The Simpsons reside?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -485,56 +613,86 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "STATE" ],
         "options" : 
         [ 
           { "value" : "1",
-            "label" : "\"Washington\"" },
+            "label" : 
+            { "value" : "\"Washington\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "2",
-            "label" : "\"Kentucky\"" },
+            "label" : 
+            { "value" : "\"Kentucky\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "3",
-            "label" : "\"Ohio\"" },
+            "label" : 
+            { "value" : "\"Ohio\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "4",
-            "label" : "\"Maine\"" },
+            "label" : 
+            { "value" : "\"Maine\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "5",
-            "label" : "\"North Dakota\"" },
+            "label" : 
+            { "value" : "\"North Dakota\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "6",
-            "label" : "\"Florida\"" },
+            "label" : 
+            { "value" : "\"Florida\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "7",
-            "label" : "\"North Takoma\"" },
+            "label" : 
+            { "value" : "\"North Takoma\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "8",
-            "label" : "\"California\"" },
+            "label" : 
+            { "value" : "\"California\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "9",
-            "label" : "\"Texas\"" },
+            "label" : 
+            { "value" : "\"Texas\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "10",
-            "label" : "\"Massachusetts\"" },
+            "label" : 
+            { "value" : "\"Massachusetts\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "11",
-            "label" : "\"Nevada\"" },
+            "label" : 
+            { "value" : "\"Nevada\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "12",
-            "label" : "\"Illinois\"" },
+            "label" : 
+            { "value" : "\"Illinois\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "13",
-            "label" : "\"Not in any state, you fool!\"" } ],
+            "label" : 
+            { "value" : "\"Not in any state, you fool!\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "STATE" } },
       
       { "id" : "j6qe0h9q",
         "componentType" : "Sequence",
         "page" : "18",
-        "label" : "\"III - Characters\"",
+        "label" : 
+        { "value" : "\"III - Characters\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -543,18 +701,24 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j334akov",
         "componentType" : "CheckboxGroup",
         "page" : "19",
-        "label" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+        "label" : 
+        { "value" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j334akov-d5",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Several possible answers\"" } ],
+            "label" : 
+            { "value" : "\"Several possible answers\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -563,7 +727,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PET1",
           "PET2",
@@ -572,22 +738,30 @@
         "responses" : 
         [ 
           { "id" : "j334akov-QOP-khokqjtw",
-            "label" : "\"Santa’s Little Helper\"",
+            "label" : 
+            { "value" : "\"Santa’s Little Helper\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET1" } },
           
           { "id" : "j334akov-QOP-khokur7a",
-            "label" : "\"Snowball I\"",
+            "label" : 
+            { "value" : "\"Snowball I\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET2" } },
           
           { "id" : "j334akov-QOP-khol82ux",
-            "label" : "\"Coltrane\"",
+            "label" : 
+            { "value" : "\"Coltrane\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET3" } },
           
           { "id" : "j334akov-QOP-khokqee5",
-            "label" : "\"Other name\"",
+            "label" : 
+            { "value" : "\"Other name\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET4" } } ] },
       
@@ -596,13 +770,17 @@
         "mandatory" : false,
         "page" : "20",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+        "label" : 
+        { "value" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "d12-SI",
             "declarationType" : "STATEMENT",
             "position" : "BEFORE_QUESTION_TEXT",
-            "label" : "\"Now we are going to know if you think that Jay is a gluton.\"" } ],
+            "label" : 
+            { "value" : "\"Now we are going to know if you think that Jay is a gluton.\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -611,7 +789,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "ICE_FLAVOUR1",
           "ICE_FLAVOUR2",
@@ -621,17 +801,23 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Vanilla\"" },
+              "label" : 
+              { "value" : "\"Vanilla\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5w99y",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR1" },
               "bindingDependencies" : 
@@ -639,17 +825,23 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Strawberry\"" },
+              "label" : 
+              { "value" : "\"Strawberry\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5ummf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR2" },
               "bindingDependencies" : 
@@ -657,17 +849,23 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Apple\"" },
+              "label" : 
+              { "value" : "\"Apple\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5mry5",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR3" },
               "bindingDependencies" : 
@@ -675,17 +873,23 @@
           
           [ 
             { "value" : "OT",
-              "label" : "\"Other flavour\"" },
+              "label" : 
+              { "value" : "\"Other flavour\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5lkr8",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR4" },
               "bindingDependencies" : 
@@ -696,7 +900,9 @@
         "mandatory" : false,
         "page" : "21",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -705,7 +911,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NUCLEAR_CHARACTER1",
           "NUCLEAR_CHARACTER2",
@@ -715,17 +923,23 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Charles Montgomery Burns\"" },
+              "label" : 
+              { "value" : "\"Charles Montgomery Burns\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewva8xg",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER1" },
               "bindingDependencies" : 
@@ -733,17 +947,23 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Carl Carlson\"" },
+              "label" : 
+              { "value" : "\"Carl Carlson\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewvj0ad",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER2" },
               "bindingDependencies" : 
@@ -751,17 +971,23 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Otto Mann\"" },
+              "label" : 
+              { "value" : "\"Otto Mann\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewveltm",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER3" },
               "bindingDependencies" : 
@@ -769,17 +995,23 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Lenny Leonard\"" },
+              "label" : 
+              { "value" : "\"Lenny Leonard\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewvgax4",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER4" },
               "bindingDependencies" : 
@@ -790,7 +1022,9 @@
         "mandatory" : false,
         "page" : "22",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 4. In which city each character was born?\"",
+        "label" : 
+        { "value" : "\"➡ 4. In which city each character was born?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -799,7 +1033,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "BIRTH_CHARACTER1",
           "BIRTH_CHARACTER2",
@@ -810,26 +1046,38 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Selma Bouvier\"" },
+              "label" : 
+              { "value" : "\"Selma Bouvier\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvjvcs",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER1" },
               "bindingDependencies" : 
@@ -837,26 +1085,38 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Kent Brockman\"" },
+              "label" : 
+              { "value" : "\"Kent Brockman\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvhoda",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER2" },
               "bindingDependencies" : 
@@ -864,26 +1124,38 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Milhouse Van Houten\"" },
+              "label" : 
+              { "value" : "\"Milhouse Van Houten\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewv64s5",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER3" },
               "bindingDependencies" : 
@@ -891,26 +1163,38 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Nelson Muntz\"" },
+              "label" : 
+              { "value" : "\"Nelson Muntz\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvj21j",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER4" },
               "bindingDependencies" : 
@@ -918,26 +1202,38 @@
           
           [ 
             { "value" : "5",
-              "label" : "\"Crazy Cat Lady\"" },
+              "label" : 
+              { "value" : "\"Crazy Cat Lady\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewva5uf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER5" },
               "bindingDependencies" : 
@@ -946,7 +1242,9 @@
       { "id" : "j4nw88h2",
         "componentType" : "Sequence",
         "page" : "23",
-        "label" : "\"IV - General questions\"",
+        "label" : 
+        { "value" : "\"IV - General questions\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -955,12 +1253,16 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" } } },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6qe237q",
         "componentType" : "Subsequence",
         "goToPage" : "24",
-        "label" : "\"Kwik-E-Mart\"",
+        "label" : 
+        { "value" : "\"Kwik-E-Mart\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -969,18 +1271,24 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j4nwc63q",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "24",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -989,11 +1297,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PERCENTAGE_EXPENSES11",
           "PERCENTAGE_EXPENSES21",
@@ -1007,18 +1319,26 @@
           [ 
             { "headerCell" : true,
               "colspan" : 2,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Percentage\"" } ],
+              "label" : 
+              { "value" : "\"Percentage\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "rowspan" : 2,
               "value" : "A",
-              "label" : "\"Frozen products\"" },
+              "label" : 
+              { "value" : "\"Frozen products\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "A1",
-              "label" : "\"Ice creams\"" },
+              "label" : 
+              { "value" : "\"Ice creams\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1033,7 +1353,9 @@
           
           [ 
             { "value" : "A2",
-              "label" : "\"Jasper Beardly\"" },
+              "label" : 
+              { "value" : "\"Jasper Beardly\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1049,10 +1371,14 @@
           [ 
             { "rowspan" : 3,
               "value" : "B",
-              "label" : "\"Meat\"" },
+              "label" : 
+              { "value" : "\"Meat\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "B1",
-              "label" : "\"Bacon\"" },
+              "label" : 
+              { "value" : "\"Bacon\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1067,7 +1393,9 @@
           
           [ 
             { "value" : "B2",
-              "label" : "\"Pork chop\"" },
+              "label" : 
+              { "value" : "\"Pork chop\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1082,7 +1410,9 @@
           
           [ 
             { "value" : "B3",
-              "label" : "\"Chicken\"" },
+              "label" : 
+              { "value" : "\"Chicken\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1097,10 +1427,14 @@
           
           [ 
             { "value" : "C",
-              "label" : "\"Compote\"" },
+              "label" : 
+              { "value" : "\"Compote\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "C1",
-              "label" : "\"Powersauce\"" },
+              "label" : 
+              { "value" : "\"Powersauce\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1116,7 +1450,9 @@
           [ 
             { "colspan" : 2,
               "value" : "D",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1132,7 +1468,9 @@
           [ 
             { "colspan" : 2,
               "value" : "E",
-              "label" : "\"Total\"" },
+              "label" : 
+              { "value" : "\"Total\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : false } ] ] },
       
@@ -1141,7 +1479,9 @@
         "mandatory" : false,
         "page" : "25",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+        "label" : 
+        { "value" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1150,11 +1490,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "LAST_FOOD_SHOPPING11",
           "LAST_FOOD_SHOPPING21",
@@ -1169,31 +1513,45 @@
           [ 
             { "headerCell" : true,
               "colspan" : 2,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"In his last food shopping\"" } ],
+              "label" : 
+              { "value" : "\"In his last food shopping\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "rowspan" : 2,
               "value" : "A",
-              "label" : "\"Frozen products\"" },
+              "label" : 
+              { "value" : "\"Frozen products\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "A1",
-              "label" : "\"Ice creams\"" },
+              "label" : 
+              { "value" : "\"Ice creams\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6pljq",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING11" },
               "bindingDependencies" : 
@@ -1201,20 +1559,28 @@
           
           [ 
             { "value" : "A2",
-              "label" : "\"Jasper Beardly\"" },
+              "label" : 
+              { "value" : "\"Jasper Beardly\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6mgpv",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING21" },
               "bindingDependencies" : 
@@ -1223,23 +1589,33 @@
           [ 
             { "rowspan" : 3,
               "value" : "B",
-              "label" : "\"Meat\"" },
+              "label" : 
+              { "value" : "\"Meat\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "B1",
-              "label" : "\"Bacon\"" },
+              "label" : 
+              { "value" : "\"Bacon\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6pmtz",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING31" },
               "bindingDependencies" : 
@@ -1247,20 +1623,28 @@
           
           [ 
             { "value" : "B2",
-              "label" : "\"Pork chop\"" },
+              "label" : 
+              { "value" : "\"Pork chop\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6k4lf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING41" },
               "bindingDependencies" : 
@@ -1268,20 +1652,28 @@
           
           [ 
             { "value" : "B3",
-              "label" : "\"Chicken\"" },
+              "label" : 
+              { "value" : "\"Chicken\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6p70n",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING51" },
               "bindingDependencies" : 
@@ -1289,23 +1681,33 @@
           
           [ 
             { "value" : "C",
-              "label" : "\"Compote\"" },
+              "label" : 
+              { "value" : "\"Compote\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "C1",
-              "label" : "\"Powersauce\"" },
+              "label" : 
+              { "value" : "\"Powersauce\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6lh5v",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING61" },
               "bindingDependencies" : 
@@ -1314,20 +1716,28 @@
           [ 
             { "colspan" : 2,
               "value" : "D",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq703te",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING71" },
               "bindingDependencies" : 
@@ -1336,20 +1746,28 @@
           [ 
             { "colspan" : 2,
               "value" : "E",
-              "label" : "\"Total\"" },
+              "label" : 
+              { "value" : "\"Total\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6zpd3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING81" },
               "bindingDependencies" : 
@@ -1358,7 +1776,9 @@
       { "id" : "j6qejudb",
         "componentType" : "Subsequence",
         "goToPage" : "26",
-        "label" : "\"Clowning\"",
+        "label" : 
+        { "value" : "\"Clowning\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1367,18 +1787,24 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qejudb",
             "page" : "26",
-            "label" : "\"Clowning\"" } } },
+            "label" : 
+            { "value" : "\"Clowning\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "kbkjvgel",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "26",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1387,11 +1813,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qejudb",
             "page" : "26",
-            "label" : "\"Clowning\"" } },
+            "label" : 
+            { "value" : "\"Clowning\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "CLOWNING11",
           "CLOWNING12",
@@ -1405,33 +1835,49 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Clowning\"" },
+              "label" : 
+              { "value" : "\"Clowning\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Remember?\"" } ],
+              "label" : 
+              { "value" : "\"Remember?\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Break the windows of the whole city\"" },
+              "label" : 
+              { "value" : "\"Break the windows of the whole city\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6m5n0",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING11" },
               "bindingDependencies" : 
@@ -1447,23 +1893,33 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Loose the violin of his daughter playing poker\"" },
+              "label" : 
+              { "value" : "\"Loose the violin of his daughter playing poker\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6l29o",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING21" },
               "bindingDependencies" : 
@@ -1479,23 +1935,33 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Kill Mr Burns\"" },
+              "label" : 
+              { "value" : "\"Kill Mr Burns\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq72biw",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING31" },
               "bindingDependencies" : 
@@ -1511,23 +1977,33 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Leaving a mechanical object to control the nuclear power plant\"" },
+              "label" : 
+              { "value" : "\"Leaving a mechanical object to control the nuclear power plant\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6mlan",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING41" },
               "bindingDependencies" : 
@@ -1544,7 +2020,9 @@
       { "id" : "j6qeh91y",
         "componentType" : "Subsequence",
         "goToPage" : "27",
-        "label" : "\"Transport\"",
+        "label" : 
+        { "value" : "\"Transport\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1553,24 +2031,32 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qeh91y",
             "page" : "27",
-            "label" : "\"Transport\"" } } },
+            "label" : 
+            { "value" : "\"Transport\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p2lwuj",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "27",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+        "label" : 
+        { "value" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p2lwuj-d10",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Several answers possible: check off all the relevant boxes\"" } ],
+            "label" : 
+            { "value" : "\"Several answers possible: check off all the relevant boxes\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1579,11 +2065,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qeh91y",
             "page" : "27",
-            "label" : "\"Transport\"" } },
+            "label" : 
+            { "value" : "\"Transport\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "TRAVEL11",
           "TRAVEL12",
@@ -1613,29 +2103,45 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Brazil\"" },
+              "label" : 
+              { "value" : "\"Brazil\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Canada\"" },
+              "label" : 
+              { "value" : "\"Canada\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Japan\"" },
+              "label" : 
+              { "value" : "\"Japan\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"France\"" },
+              "label" : 
+              { "value" : "\"France\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Other country\"" },
+              "label" : 
+              { "value" : "\"Other country\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Other planet\"" } ],
+              "label" : 
+              { "value" : "\"Other planet\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Car\"" },
+              "label" : 
+              { "value" : "\"Car\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvm4qg",
@@ -1681,7 +2187,9 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Bike\"" },
+              "label" : 
+              { "value" : "\"Bike\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvebem",
@@ -1727,7 +2235,9 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Skateboard\"" },
+              "label" : 
+              { "value" : "\"Skateboard\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewv62xx",
@@ -1773,7 +2283,9 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Plane\"" },
+              "label" : 
+              { "value" : "\"Plane\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvjcck",
@@ -1820,7 +2332,9 @@
       { "id" : "j6qfx9qe",
         "componentType" : "Sequence",
         "page" : "28",
-        "label" : "\"V - Favourite characters (dynamic table)\"",
+        "label" : 
+        { "value" : "\"V - Favourite characters (dynamic table)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1829,14 +2343,18 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6qg8rc6",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "29",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+        "label" : 
+        { "value" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1845,7 +2363,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "FAVOURITE_CHAR1",
           "FAVOURITE_CHAR2",
@@ -1887,13 +2407,19 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "\"Name\"" },
+              "label" : 
+              { "value" : "\"Name\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Age\"" },
+              "label" : 
+              { "value" : "\"Age\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Member of the Simpsons family\"" } ],
+              "label" : 
+              { "value" : "\"Member of the Simpsons family\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "componentType" : "Textarea",
@@ -1917,13 +2443,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_1_3" },
               "bindingDependencies" : 
@@ -1951,13 +2483,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_2_3" },
               "bindingDependencies" : 
@@ -1985,13 +2523,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_3_3" },
               "bindingDependencies" : 
@@ -2019,13 +2563,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_4_3" },
               "bindingDependencies" : 
@@ -2053,13 +2603,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_5_3" },
               "bindingDependencies" : 
@@ -2087,13 +2643,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_6_3" },
               "bindingDependencies" : 
@@ -2121,13 +2683,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_7_3" },
               "bindingDependencies" : 
@@ -2155,13 +2723,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_8_3" },
               "bindingDependencies" : 
@@ -2189,13 +2763,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_9_3" },
               "bindingDependencies" : 
@@ -2223,13 +2803,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_10_3" },
               "bindingDependencies" : 
@@ -2240,7 +2826,9 @@
         "mandatory" : false,
         "page" : "30",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+        "label" : 
+        { "value" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2249,7 +2837,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "FEELCHAREV1",
           "FEELCHAREV2",
@@ -2259,20 +2849,28 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Jay\"" },
+              "label" : 
+              { "value" : "\"Jay\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq76emy",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV1" },
               "bindingDependencies" : 
@@ -2280,20 +2878,28 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Bart\"" },
+              "label" : 
+              { "value" : "\"Bart\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq6zv60",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV2" },
               "bindingDependencies" : 
@@ -2301,20 +2907,28 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Krusty the clown\"" },
+              "label" : 
+              { "value" : "\"Krusty the clown\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq7bgk3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV3" },
               "bindingDependencies" : 
@@ -2322,20 +2936,28 @@
           
           [ 
             { "value" : "O",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq6ync3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV4" },
               "bindingDependencies" : 
@@ -2346,7 +2968,9 @@
         "mandatory" : false,
         "page" : "31",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2355,7 +2979,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "LEAVDURATION11",
           "LEAVDURATION12",
@@ -2371,17 +2997,25 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Days\"" },
+              "label" : 
+              { "value" : "\"Days\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Unit\"" } ],
+              "label" : 
+              { "value" : "\"Unit\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Leave with pay\"" },
+              "label" : 
+              { "value" : "\"Leave with pay\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2398,10 +3032,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION12" },
               "bindingDependencies" : 
@@ -2409,7 +3047,9 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Public holiday\"" },
+              "label" : 
+              { "value" : "\"Public holiday\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2426,10 +3066,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION22" },
               "bindingDependencies" : 
@@ -2437,7 +3081,9 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Sick leave\"" },
+              "label" : 
+              { "value" : "\"Sick leave\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2454,10 +3100,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION32" },
               "bindingDependencies" : 
@@ -2465,7 +3115,9 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Maternity\/paternity leave\"" },
+              "label" : 
+              { "value" : "\"Maternity\/paternity leave\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2482,10 +3134,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION42" },
               "bindingDependencies" : 
@@ -2493,7 +3149,9 @@
           
           [ 
             { "value" : "5",
-              "label" : "\"Other type\"" },
+              "label" : 
+              { "value" : "\"Other type\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2510,10 +3168,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION52" },
               "bindingDependencies" : 
@@ -2522,7 +3184,9 @@
       { "id" : "kiq5mr0b",
         "componentType" : "Sequence",
         "page" : "32",
-        "label" : "\"VI - Favourite characters (Loop)\"",
+        "label" : 
+        { "value" : "\"VI - Favourite characters (Loop)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2531,7 +3195,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "kiq612ky",
         "componentType" : "InputNumber",
@@ -2540,7 +3206,9 @@
         "min" : 0,
         "max" : 20,
         "decimals" : 0,
-        "label" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+        "label" : 
+        { "value" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2549,7 +3217,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NB_CHAR" ],
         "response" : 
@@ -2559,7 +3229,9 @@
         "componentType" : "Loop",
         "page" : "34",
         "paginatedLoop" : false,
-        "label" : "\"Add a character\"",
+        "label" : 
+        { "value" : "\"Add a character\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2568,7 +3240,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NAME_CHAR",
           "AGE_CHAR" ],
@@ -2578,7 +3252,9 @@
             "componentType" : "Subsequence",
             "page" : "34",
             "goToPage" : "34",
-            "label" : "\"Description of each character\"",
+            "label" : 
+            { "value" : "\"Description of each character\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2587,18 +3263,24 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } } },
           
           { "id" : "kiq66gtw",
             "componentType" : "Input",
             "mandatory" : false,
             "page" : "34",
             "maxLength" : 30,
-            "label" : "\"➡ 2. What is the first name of this character?\"",
+            "label" : 
+            { "value" : "\"➡ 2. What is the first name of this character?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2607,11 +3289,15 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR" ],
             "response" : 
@@ -2624,7 +3310,9 @@
             "min" : 0,
             "max" : 120,
             "decimals" : 0,
-            "label" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+            "label" : 
+            { "value" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2633,11 +3321,15 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "AGE_CHAR" ],
             "response" : 
@@ -2666,7 +3358,9 @@
           { "id" : "kiq5xw5p",
             "componentType" : "Sequence",
             "page" : "35.1",
-            "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+            "label" : 
+            { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2675,7 +3369,9 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR" ] },
           
@@ -2683,7 +3379,9 @@
             "componentType" : "CheckboxOne",
             "mandatory" : false,
             "page" : "35.2",
-            "label" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+            "label" : 
+            { "value" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2692,17 +3390,23 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR",
               "FAVCHAR" ],
             "options" : 
             [ 
               { "value" : "1",
-                "label" : "\"Yes\"" },
+                "label" : 
+                { "value" : "\"Yes\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "0",
-                "label" : "\"No\"" } ],
+                "label" : 
+                { "value" : "\"No\"",
+                  "type" : "VTL|MD" } } ],
             "response" : 
             { "name" : "FAVCHAR" } },
           
@@ -2711,7 +3415,9 @@
             "mandatory" : false,
             "page" : "35.3",
             "maxLength" : 255,
-            "label" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+            "label" : 
+            { "value" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2720,7 +3426,9 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR",
               "MEMORY_CHAR" ],
@@ -2730,28 +3438,36 @@
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
         "page" : "36",
-        "label" : "\"VIII - Comment\"",
+        "label" : 
+        { "value" : "\"VIII - Comment\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
             "page" : "36",
-            "label" : "\"VIII - Comment\"" } } },
+            "label" : 
+            { "value" : "\"VIII - Comment\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6z0z3us",
         "componentType" : "Textarea",
         "mandatory" : false,
         "page" : "37",
         "maxLength" : 255,
-        "label" : "\"➡ 1. Do you have any comment about the survey?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
             "page" : "36",
-            "label" : "\"VIII - Comment\"" } },
+            "label" : 
+            { "value" : "\"VIII - Comment\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "SURVEY_COMMENT" ],
         "response" : 

--- a/src/test/resources/examples/xmlf-2-jsonf/out.json
+++ b/src/test/resources/examples/xmlf-2-jsonf/out.json
@@ -3,7 +3,7 @@
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
     "lunaticModelVersion" : "2.2.11",
-    "generatingDate" : "11-03-2022 14:52:01",
+    "generatingDate" : "15-03-2022 13:41:50",
     "pagination" : "question",
     "maxPage" : "37",
     "label" : 
@@ -26,7 +26,8 @@
             { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -44,7 +45,8 @@
         { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -73,7 +75,8 @@
             { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -94,7 +97,8 @@
         { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -111,6 +115,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -137,6 +142,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -169,6 +175,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -208,6 +215,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -247,6 +255,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -287,6 +296,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -320,6 +330,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -353,6 +364,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -386,6 +398,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -419,6 +432,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -452,6 +466,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -489,6 +504,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -516,6 +532,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -563,6 +580,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -607,6 +625,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -695,6 +714,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -721,6 +741,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -783,6 +804,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -905,6 +927,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1027,6 +1050,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1247,6 +1271,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1265,6 +1290,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1291,6 +1317,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1484,6 +1511,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1781,6 +1809,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1807,6 +1836,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2025,6 +2055,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2059,6 +2090,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2337,6 +2369,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2357,6 +2390,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2401,8 +2435,12 @@
           "FAVOURITE_CHAR2_10_2",
           "FAVOURITE_CHAR3_10_3" ],
         "lines" : 
-        { "min" : 1,
-          "max" : 10 },
+        { "min" : 
+          { "value" : "1",
+            "type" : "VTL|MD" },
+          "max" : 
+          { "value" : "10",
+            "type" : "VTL|MD" } },
         "cells" : 
         [ 
           [ 
@@ -2831,6 +2869,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2973,6 +3012,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3189,6 +3229,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3211,6 +3252,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3234,6 +3276,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3257,6 +3300,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3283,6 +3327,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3315,6 +3360,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3339,11 +3385,11 @@
         "componentType" : "Loop",
         "page" : "35",
         "maxPage" : "3",
-        "iterations" : "count(NAME_CHAR)",
         "depth" : 1,
         "paginatedLoop" : true,
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "bindingDependencies" : 
@@ -3363,6 +3409,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3384,6 +3431,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3420,6 +3468,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3433,7 +3482,10 @@
             [ "NAME_CHAR",
               "MEMORY_CHAR" ],
             "response" : 
-            { "name" : "MEMORY_CHAR" } } ] },
+            { "name" : "MEMORY_CHAR" } } ],
+        "iterations" : 
+        { "value" : "count(NAME_CHAR)",
+          "type" : "VTL|MD" } },
       
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
@@ -3442,7 +3494,8 @@
         { "value" : "\"VIII - Comment\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
@@ -3460,7 +3513,8 @@
         { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",

--- a/src/test/resources/examples/xmlh-2-jsonf/out.json
+++ b/src/test/resources/examples/xmlh-2-jsonf/out.json
@@ -3,7 +3,7 @@
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
     "lunaticModelVersion" : "2.2.11",
-    "generatingDate" : "11-03-2022 11:35:02",
+    "generatingDate" : "15-03-2022 13:41:50",
     "pagination" : "question",
     "maxPage" : "37",
     "label" : 
@@ -26,7 +26,8 @@
             { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -44,7 +45,8 @@
         { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -73,7 +75,8 @@
             { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -94,7 +97,8 @@
         { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -111,6 +115,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -137,6 +142,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -169,6 +175,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -208,6 +215,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -247,6 +255,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -287,6 +296,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -320,6 +330,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -353,6 +364,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -386,6 +398,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -419,6 +432,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -452,6 +466,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -489,6 +504,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -516,6 +532,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -563,6 +580,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -607,6 +625,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -695,6 +714,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -721,6 +741,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -783,6 +804,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -905,6 +927,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1027,6 +1050,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1247,6 +1271,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1265,6 +1290,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1291,6 +1317,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1484,6 +1511,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1781,6 +1809,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1807,6 +1836,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2025,6 +2055,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2059,6 +2090,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2337,6 +2369,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2357,6 +2390,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2401,8 +2435,12 @@
           "FAVOURITE_CHAR2_10_2",
           "FAVOURITE_CHAR3_10_3" ],
         "lines" : 
-        { "min" : 1,
-          "max" : 10 },
+        { "min" : 
+          { "value" : "1",
+            "type" : "VTL|MD" },
+          "max" : 
+          { "value" : "10",
+            "type" : "VTL|MD" } },
         "cells" : 
         [ 
           [ 
@@ -2831,6 +2869,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2973,6 +3012,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3189,6 +3229,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3211,6 +3252,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3234,6 +3276,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3257,6 +3300,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3283,6 +3327,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3315,6 +3360,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3339,11 +3385,11 @@
         "componentType" : "Loop",
         "page" : "35",
         "maxPage" : "3",
-        "iterations" : "count(NAME_CHAR)",
         "depth" : 1,
         "paginatedLoop" : true,
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "bindingDependencies" : 
@@ -3363,6 +3409,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3384,6 +3431,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3420,6 +3468,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3433,7 +3482,10 @@
             [ "NAME_CHAR",
               "MEMORY_CHAR" ],
             "response" : 
-            { "name" : "MEMORY_CHAR" } } ] },
+            { "name" : "MEMORY_CHAR" } } ],
+        "iterations" : 
+        { "value" : "count(NAME_CHAR)",
+          "type" : "VTL|MD" } },
       
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
@@ -3442,7 +3494,8 @@
         { "value" : "\"VIII - Comment\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
@@ -3460,7 +3513,8 @@
         { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",

--- a/src/test/resources/examples/xmlh-2-jsonf/out.json
+++ b/src/test/resources/examples/xmlh-2-jsonf/out.json
@@ -2,44 +2,56 @@
   { "id" : "i6vwi2506qf2mms",
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
-    "lunaticModelVersion" : "2.1.2",
-    "generatingDate" : "28-06-2021 17:07:23",
+    "lunaticModelVersion" : "2.2.11",
+    "generatingDate" : "11-03-2022 11:35:02",
     "pagination" : "question",
     "maxPage" : "37",
-    "label" : "Questionnaire SIMPSONS 20201215",
+    "label" : 
+    { "value" : "Questionnaire SIMPSONS 20201215",
+      "type" : "VTL|MD" },
     "components" : 
     [ 
       { "id" : "j6p0ti5h",
         "componentType" : "Sequence",
         "page" : "1",
-        "label" : "\"I - Introduction\"",
+        "label" : 
+        { "value" : "\"I - Introduction\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p0ti5h-d1",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"" } ],
+            "label" : 
+            { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p3dkx6",
         "componentType" : "Textarea",
         "mandatory" : true,
         "page" : "2",
         "maxLength" : 500,
-        "label" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "COMMENT" ],
         "response" : 
@@ -49,20 +61,26 @@
         "componentType" : "CheckboxBoolean",
         "mandatory" : false,
         "page" : "3",
-        "label" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+        "label" : 
+        { "value" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p0np9q-kir6xl1e",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"If not, this is unfortunately the end of this questionnaire.\"" } ],
+            "label" : 
+            { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "READY" ],
         "response" : 
@@ -72,19 +90,25 @@
         "componentType" : "FilterDescription",
         "page" : "3",
         "filterDescription" : false,
-        "label" : "\"If you are not ready, please go to the end of the questionnaire\"",
+        "label" : 
+        { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p0s7o5",
         "componentType" : "Subsequence",
         "goToPage" : "4",
-        "label" : "\"General knowledge of the series\"",
+        "label" : 
+        { "value" : "\"General knowledge of the series\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -93,18 +117,24 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j3343qhx",
         "componentType" : "Input",
         "mandatory" : false,
         "page" : "4",
         "maxLength" : 30,
-        "label" : "\"➡ 3. Who is the producer?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Who is the producer?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -113,11 +143,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PRODUCER" ],
         "response" : 
@@ -130,7 +164,9 @@
         "min" : 0,
         "max" : 99,
         "decimals" : 0,
-        "label" : "\"➡ 4. What is the current season number?\"",
+        "label" : 
+        { "value" : "\"➡ 4. What is the current season number?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -139,11 +175,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "SEASON_NUMBER" ],
         "response" : 
@@ -155,13 +195,17 @@
         "page" : "6",
         "min" : "1900-01-01",
         "max" : "format-date(current-date(),'[Y0001]-[M01]-[D01]')",
-        "label" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+        "label" : 
+        { "value" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "kiq71eoi-kiq7dsy2",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY-MM-DD format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY-MM-DD format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -170,11 +214,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEFIRST" ],
         "dateFormat" : "YYYY-MM-DD",
@@ -186,13 +234,17 @@
         "mandatory" : false,
         "page" : "7",
         "min" : "1980-05",
-        "label" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+        "label" : 
+        { "value" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "k5nvty2o-k5nvxld8",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY-MM format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY-MM format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -201,11 +253,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEYYYYMM" ],
         "dateFormat" : "YYYY-MM",
@@ -218,13 +274,17 @@
         "page" : "8",
         "min" : "1900",
         "max" : "year-from-date(current-date())",
-        "label" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+        "label" : 
+        { "value" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "k5nw1fir-k5nvmx3n",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Please answer with YYYY format\"" } ],
+            "label" : 
+            { "value" : "\"Please answer with YYYY format\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -233,11 +293,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DATEYYYY" ],
         "dateFormat" : "YYYY",
@@ -251,7 +315,9 @@
         "min" : 0,
         "max" : 70,
         "decimals" : 2,
-        "label" : "\"➡ 8. How long does an episode last?\"",
+        "label" : 
+        { "value" : "\"➡ 8. How long does an episode last?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -260,11 +326,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONH" ],
         "unit" : "heures",
@@ -278,7 +348,9 @@
         "min" : 0,
         "max" : 366,
         "decimals" : 1,
-        "label" : "\"➡ 9. How long does it take to write a new episode?\"",
+        "label" : 
+        { "value" : "\"➡ 9. How long does it take to write a new episode?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -287,11 +359,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIOND" ],
         "unit" : "jours",
@@ -305,7 +381,9 @@
         "min" : 0,
         "max" : 12,
         "decimals" : 0,
-        "label" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+        "label" : 
+        { "value" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -314,11 +392,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONM" ],
         "unit" : "mois",
@@ -332,7 +414,9 @@
         "min" : 0,
         "max" : 100,
         "decimals" : 0,
-        "label" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+        "label" : 
+        { "value" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -341,11 +425,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "DURATIONY" ],
         "unit" : "années",
@@ -359,7 +447,9 @@
         "min" : 0,
         "max" : 99,
         "decimals" : 1,
-        "label" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+        "label" : 
+        { "value" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -368,11 +458,15 @@
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6p0s7o5",
             "page" : "4",
-            "label" : "\"General knowledge of the series\"" } },
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "AUDIENCE_SHARE" ],
         "unit" : "%",
@@ -382,13 +476,17 @@
       { "id" : "j3341528",
         "componentType" : "Sequence",
         "page" : "14",
-        "label" : "\"II - Simpsons’ city\"",
+        "label" : 
+        { "value" : "\"II - Simpsons’ city\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j3341528-d2",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"This module asks about your general knowledge of the Simpsons city\"" } ],
+            "label" : 
+            { "value" : "\"This module asks about your general knowledge of the Simpsons city\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -397,19 +495,25 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j3343clt",
         "componentType" : "Radio",
         "mandatory" : true,
         "page" : "15",
-        "label" : "\"➡ 1. In which city do the Simpsons reside?\"",
+        "label" : 
+        { "value" : "\"➡ 1. In which city do the Simpsons reside?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j3343clt-d3",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"One possible answer\"" } ],
+            "label" : 
+            { "value" : "\"One possible answer\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -418,19 +522,27 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "CITY" ],
         "options" : 
         [ 
           { "value" : "00001",
-            "label" : "\"Springfield\"" },
+            "label" : 
+            { "value" : "\"Springfield\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "00002",
-            "label" : "\"Shelbyville\"" },
+            "label" : 
+            { "value" : "\"Shelbyville\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "03",
-            "label" : "\"Seinfeld\"" } ],
+            "label" : 
+            { "value" : "\"Seinfeld\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "CITY" } },
       
@@ -438,13 +550,17 @@
         "componentType" : "CheckboxOne",
         "mandatory" : false,
         "page" : "16",
-        "label" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+        "label" : 
+        { "value" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6qdfhvw-d4",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Only one possible answer\"" } ],
+            "label" : 
+            { "value" : "\"Only one possible answer\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -453,22 +569,32 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "MAYOR" ],
         "options" : 
         [ 
           { "value" : "1",
-            "label" : "\"Constance Harm\"" },
+            "label" : 
+            { "value" : "\"Constance Harm\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "2",
-            "label" : "\"Timothy Lovejoy\"" },
+            "label" : 
+            { "value" : "\"Timothy Lovejoy\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "3",
-            "label" : "\"Joe Quimby\"" },
+            "label" : 
+            { "value" : "\"Joe Quimby\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "OT",
-            "label" : "\"Other name\"" } ],
+            "label" : 
+            { "value" : "\"Other name\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "MAYOR" } },
       
@@ -476,7 +602,9 @@
         "componentType" : "Dropdown",
         "mandatory" : false,
         "page" : "17",
-        "label" : "\"➡ 3. In which state do The Simpsons reside?\"",
+        "label" : 
+        { "value" : "\"➡ 3. In which state do The Simpsons reside?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -485,56 +613,86 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "STATE" ],
         "options" : 
         [ 
           { "value" : "1",
-            "label" : "\"Washington\"" },
+            "label" : 
+            { "value" : "\"Washington\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "2",
-            "label" : "\"Kentucky\"" },
+            "label" : 
+            { "value" : "\"Kentucky\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "3",
-            "label" : "\"Ohio\"" },
+            "label" : 
+            { "value" : "\"Ohio\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "4",
-            "label" : "\"Maine\"" },
+            "label" : 
+            { "value" : "\"Maine\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "5",
-            "label" : "\"North Dakota\"" },
+            "label" : 
+            { "value" : "\"North Dakota\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "6",
-            "label" : "\"Florida\"" },
+            "label" : 
+            { "value" : "\"Florida\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "7",
-            "label" : "\"North Takoma\"" },
+            "label" : 
+            { "value" : "\"North Takoma\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "8",
-            "label" : "\"California\"" },
+            "label" : 
+            { "value" : "\"California\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "9",
-            "label" : "\"Texas\"" },
+            "label" : 
+            { "value" : "\"Texas\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "10",
-            "label" : "\"Massachusetts\"" },
+            "label" : 
+            { "value" : "\"Massachusetts\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "11",
-            "label" : "\"Nevada\"" },
+            "label" : 
+            { "value" : "\"Nevada\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "12",
-            "label" : "\"Illinois\"" },
+            "label" : 
+            { "value" : "\"Illinois\"",
+              "type" : "VTL|MD" } },
           
           { "value" : "13",
-            "label" : "\"Not in any state, you fool!\"" } ],
+            "label" : 
+            { "value" : "\"Not in any state, you fool!\"",
+              "type" : "VTL|MD" } } ],
         "response" : 
         { "name" : "STATE" } },
       
       { "id" : "j6qe0h9q",
         "componentType" : "Sequence",
         "page" : "18",
-        "label" : "\"III - Characters\"",
+        "label" : 
+        { "value" : "\"III - Characters\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -543,18 +701,24 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j334akov",
         "componentType" : "CheckboxGroup",
         "page" : "19",
-        "label" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+        "label" : 
+        { "value" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j334akov-d5",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Several possible answers\"" } ],
+            "label" : 
+            { "value" : "\"Several possible answers\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -563,7 +727,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PET1",
           "PET2",
@@ -572,22 +738,30 @@
         "responses" : 
         [ 
           { "id" : "j334akov-QOP-khokqjtw",
-            "label" : "\"Santa’s Little Helper\"",
+            "label" : 
+            { "value" : "\"Santa’s Little Helper\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET1" } },
           
           { "id" : "j334akov-QOP-khokur7a",
-            "label" : "\"Snowball I\"",
+            "label" : 
+            { "value" : "\"Snowball I\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET2" } },
           
           { "id" : "j334akov-QOP-khol82ux",
-            "label" : "\"Coltrane\"",
+            "label" : 
+            { "value" : "\"Coltrane\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET3" } },
           
           { "id" : "j334akov-QOP-khokqee5",
-            "label" : "\"Other name\"",
+            "label" : 
+            { "value" : "\"Other name\"",
+              "type" : "VTL|MD" },
             "response" : 
             { "name" : "PET4" } } ] },
       
@@ -596,13 +770,17 @@
         "mandatory" : false,
         "page" : "20",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+        "label" : 
+        { "value" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "d12-SI",
             "declarationType" : "STATEMENT",
             "position" : "BEFORE_QUESTION_TEXT",
-            "label" : "\"Now we are going to know if you think that Jay is a gluton.\"" } ],
+            "label" : 
+            { "value" : "\"Now we are going to know if you think that Jay is a gluton.\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -611,7 +789,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "ICE_FLAVOUR1",
           "ICE_FLAVOUR2",
@@ -621,17 +801,23 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Vanilla\"" },
+              "label" : 
+              { "value" : "\"Vanilla\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5w99y",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR1" },
               "bindingDependencies" : 
@@ -639,17 +825,23 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Strawberry\"" },
+              "label" : 
+              { "value" : "\"Strawberry\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5ummf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR2" },
               "bindingDependencies" : 
@@ -657,17 +849,23 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Apple\"" },
+              "label" : 
+              { "value" : "\"Apple\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5mry5",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR3" },
               "bindingDependencies" : 
@@ -675,17 +873,23 @@
           
           [ 
             { "value" : "OT",
-              "label" : "\"Other flavour\"" },
+              "label" : 
+              { "value" : "\"Other flavour\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Radio",
               "id" : "j6p29i81-QOP-kiq5lkr8",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "ICE_FLAVOUR4" },
               "bindingDependencies" : 
@@ -696,7 +900,9 @@
         "mandatory" : false,
         "page" : "21",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -705,7 +911,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NUCLEAR_CHARACTER1",
           "NUCLEAR_CHARACTER2",
@@ -715,17 +923,23 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Charles Montgomery Burns\"" },
+              "label" : 
+              { "value" : "\"Charles Montgomery Burns\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewva8xg",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER1" },
               "bindingDependencies" : 
@@ -733,17 +947,23 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Carl Carlson\"" },
+              "label" : 
+              { "value" : "\"Carl Carlson\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewvj0ad",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER2" },
               "bindingDependencies" : 
@@ -751,17 +971,23 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Otto Mann\"" },
+              "label" : 
+              { "value" : "\"Otto Mann\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewveltm",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER3" },
               "bindingDependencies" : 
@@ -769,17 +995,23 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Lenny Leonard\"" },
+              "label" : 
+              { "value" : "\"Lenny Leonard\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "j6qefnga-QOP-kewvgax4",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "0",
-                  "label" : "\"No\"" } ],
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "NUCLEAR_CHARACTER4" },
               "bindingDependencies" : 
@@ -790,7 +1022,9 @@
         "mandatory" : false,
         "page" : "22",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 4. In which city each character was born?\"",
+        "label" : 
+        { "value" : "\"➡ 4. In which city each character was born?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -799,7 +1033,9 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "BIRTH_CHARACTER1",
           "BIRTH_CHARACTER2",
@@ -810,26 +1046,38 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Selma Bouvier\"" },
+              "label" : 
+              { "value" : "\"Selma Bouvier\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvjvcs",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER1" },
               "bindingDependencies" : 
@@ -837,26 +1085,38 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Kent Brockman\"" },
+              "label" : 
+              { "value" : "\"Kent Brockman\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvhoda",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER2" },
               "bindingDependencies" : 
@@ -864,26 +1124,38 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Milhouse Van Houten\"" },
+              "label" : 
+              { "value" : "\"Milhouse Van Houten\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewv64s5",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER3" },
               "bindingDependencies" : 
@@ -891,26 +1163,38 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Nelson Muntz\"" },
+              "label" : 
+              { "value" : "\"Nelson Muntz\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewvj21j",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER4" },
               "bindingDependencies" : 
@@ -918,26 +1202,38 @@
           
           [ 
             { "value" : "5",
-              "label" : "\"Crazy Cat Lady\"" },
+              "label" : 
+              { "value" : "\"Crazy Cat Lady\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "j6yzoc6g-QOP-kewva5uf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Albuquerque\"" },
+                  "label" : 
+                  { "value" : "\"Albuquerque\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Springfield\"" },
+                  "label" : 
+                  { "value" : "\"Springfield\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Portland\"" },
+                  "label" : 
+                  { "value" : "\"Portland\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "4",
-                  "label" : "\"Shelbyville\"" },
+                  "label" : 
+                  { "value" : "\"Shelbyville\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "5",
-                  "label" : "\"Dagstuhl\"" } ],
+                  "label" : 
+                  { "value" : "\"Dagstuhl\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "BIRTH_CHARACTER5" },
               "bindingDependencies" : 
@@ -946,7 +1242,9 @@
       { "id" : "j4nw88h2",
         "componentType" : "Sequence",
         "page" : "23",
-        "label" : "\"IV - General questions\"",
+        "label" : 
+        { "value" : "\"IV - General questions\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -955,12 +1253,16 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" } } },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6qe237q",
         "componentType" : "Subsequence",
         "goToPage" : "24",
-        "label" : "\"Kwik-E-Mart\"",
+        "label" : 
+        { "value" : "\"Kwik-E-Mart\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -969,18 +1271,24 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j4nwc63q",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "24",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -989,11 +1297,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "PERCENTAGE_EXPENSES11",
           "PERCENTAGE_EXPENSES21",
@@ -1007,18 +1319,26 @@
           [ 
             { "headerCell" : true,
               "colspan" : 2,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Percentage\"" } ],
+              "label" : 
+              { "value" : "\"Percentage\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "rowspan" : 2,
               "value" : "A",
-              "label" : "\"Frozen products\"" },
+              "label" : 
+              { "value" : "\"Frozen products\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "A1",
-              "label" : "\"Ice creams\"" },
+              "label" : 
+              { "value" : "\"Ice creams\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1033,7 +1353,9 @@
           
           [ 
             { "value" : "A2",
-              "label" : "\"Jasper Beardly\"" },
+              "label" : 
+              { "value" : "\"Jasper Beardly\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1049,10 +1371,14 @@
           [ 
             { "rowspan" : 3,
               "value" : "B",
-              "label" : "\"Meat\"" },
+              "label" : 
+              { "value" : "\"Meat\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "B1",
-              "label" : "\"Bacon\"" },
+              "label" : 
+              { "value" : "\"Bacon\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1067,7 +1393,9 @@
           
           [ 
             { "value" : "B2",
-              "label" : "\"Pork chop\"" },
+              "label" : 
+              { "value" : "\"Pork chop\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1082,7 +1410,9 @@
           
           [ 
             { "value" : "B3",
-              "label" : "\"Chicken\"" },
+              "label" : 
+              { "value" : "\"Chicken\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1097,10 +1427,14 @@
           
           [ 
             { "value" : "C",
-              "label" : "\"Compote\"" },
+              "label" : 
+              { "value" : "\"Compote\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "C1",
-              "label" : "\"Powersauce\"" },
+              "label" : 
+              { "value" : "\"Powersauce\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1116,7 +1450,9 @@
           [ 
             { "colspan" : 2,
               "value" : "D",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -1132,7 +1468,9 @@
           [ 
             { "colspan" : 2,
               "value" : "E",
-              "label" : "\"Total\"" },
+              "label" : 
+              { "value" : "\"Total\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : false } ] ] },
       
@@ -1141,7 +1479,9 @@
         "mandatory" : false,
         "page" : "25",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+        "label" : 
+        { "value" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1150,11 +1490,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qe237q",
             "page" : "24",
-            "label" : "\"Kwik-E-Mart\"" } },
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "LAST_FOOD_SHOPPING11",
           "LAST_FOOD_SHOPPING21",
@@ -1169,31 +1513,45 @@
           [ 
             { "headerCell" : true,
               "colspan" : 2,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"In his last food shopping\"" } ],
+              "label" : 
+              { "value" : "\"In his last food shopping\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "rowspan" : 2,
               "value" : "A",
-              "label" : "\"Frozen products\"" },
+              "label" : 
+              { "value" : "\"Frozen products\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "A1",
-              "label" : "\"Ice creams\"" },
+              "label" : 
+              { "value" : "\"Ice creams\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6pljq",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING11" },
               "bindingDependencies" : 
@@ -1201,20 +1559,28 @@
           
           [ 
             { "value" : "A2",
-              "label" : "\"Jasper Beardly\"" },
+              "label" : 
+              { "value" : "\"Jasper Beardly\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6mgpv",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING21" },
               "bindingDependencies" : 
@@ -1223,23 +1589,33 @@
           [ 
             { "rowspan" : 3,
               "value" : "B",
-              "label" : "\"Meat\"" },
+              "label" : 
+              { "value" : "\"Meat\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "B1",
-              "label" : "\"Bacon\"" },
+              "label" : 
+              { "value" : "\"Bacon\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6pmtz",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING31" },
               "bindingDependencies" : 
@@ -1247,20 +1623,28 @@
           
           [ 
             { "value" : "B2",
-              "label" : "\"Pork chop\"" },
+              "label" : 
+              { "value" : "\"Pork chop\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6k4lf",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING41" },
               "bindingDependencies" : 
@@ -1268,20 +1652,28 @@
           
           [ 
             { "value" : "B3",
-              "label" : "\"Chicken\"" },
+              "label" : 
+              { "value" : "\"Chicken\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6p70n",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING51" },
               "bindingDependencies" : 
@@ -1289,23 +1681,33 @@
           
           [ 
             { "value" : "C",
-              "label" : "\"Compote\"" },
+              "label" : 
+              { "value" : "\"Compote\"",
+                "type" : "VTL|MD" } },
             
             { "value" : "C1",
-              "label" : "\"Powersauce\"" },
+              "label" : 
+              { "value" : "\"Powersauce\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6lh5v",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING61" },
               "bindingDependencies" : 
@@ -1314,20 +1716,28 @@
           [ 
             { "colspan" : 2,
               "value" : "D",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq703te",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING71" },
               "bindingDependencies" : 
@@ -1336,20 +1746,28 @@
           [ 
             { "colspan" : 2,
               "value" : "E",
-              "label" : "\"Total\"" },
+              "label" : 
+              { "value" : "\"Total\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "k9cg2q5t-QOP-kiq6zpd3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LAST_FOOD_SHOPPING81" },
               "bindingDependencies" : 
@@ -1358,7 +1776,9 @@
       { "id" : "j6qejudb",
         "componentType" : "Subsequence",
         "goToPage" : "26",
-        "label" : "\"Clowning\"",
+        "label" : 
+        { "value" : "\"Clowning\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1367,18 +1787,24 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qejudb",
             "page" : "26",
-            "label" : "\"Clowning\"" } } },
+            "label" : 
+            { "value" : "\"Clowning\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "kbkjvgel",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "26",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1387,11 +1813,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qejudb",
             "page" : "26",
-            "label" : "\"Clowning\"" } },
+            "label" : 
+            { "value" : "\"Clowning\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "CLOWNING11",
           "CLOWNING12",
@@ -1405,33 +1835,49 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Clowning\"" },
+              "label" : 
+              { "value" : "\"Clowning\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Remember?\"" } ],
+              "label" : 
+              { "value" : "\"Remember?\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Break the windows of the whole city\"" },
+              "label" : 
+              { "value" : "\"Break the windows of the whole city\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6m5n0",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING11" },
               "bindingDependencies" : 
@@ -1447,23 +1893,33 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Loose the violin of his daughter playing poker\"" },
+              "label" : 
+              { "value" : "\"Loose the violin of his daughter playing poker\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6l29o",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING21" },
               "bindingDependencies" : 
@@ -1479,23 +1935,33 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Kill Mr Burns\"" },
+              "label" : 
+              { "value" : "\"Kill Mr Burns\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq72biw",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING31" },
               "bindingDependencies" : 
@@ -1511,23 +1977,33 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Leaving a mechanical object to control the nuclear power plant\"" },
+              "label" : 
+              { "value" : "\"Leaving a mechanical object to control the nuclear power plant\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "Dropdown",
               "id" : "kbkjvgel-QOP-kiq6mlan",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "O",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "CLOWNING41" },
               "bindingDependencies" : 
@@ -1544,7 +2020,9 @@
       { "id" : "j6qeh91y",
         "componentType" : "Subsequence",
         "goToPage" : "27",
-        "label" : "\"Transport\"",
+        "label" : 
+        { "value" : "\"Transport\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1553,24 +2031,32 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qeh91y",
             "page" : "27",
-            "label" : "\"Transport\"" } } },
+            "label" : 
+            { "value" : "\"Transport\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6p2lwuj",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "27",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+        "label" : 
+        { "value" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p2lwuj-d10",
             "declarationType" : "INSTRUCTION",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"Several answers possible: check off all the relevant boxes\"" } ],
+            "label" : 
+            { "value" : "\"Several answers possible: check off all the relevant boxes\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1579,11 +2065,15 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } },
           "subSequence" : 
           { "id" : "j6qeh91y",
             "page" : "27",
-            "label" : "\"Transport\"" } },
+            "label" : 
+            { "value" : "\"Transport\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "TRAVEL11",
           "TRAVEL12",
@@ -1613,29 +2103,45 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Brazil\"" },
+              "label" : 
+              { "value" : "\"Brazil\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Canada\"" },
+              "label" : 
+              { "value" : "\"Canada\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Japan\"" },
+              "label" : 
+              { "value" : "\"Japan\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"France\"" },
+              "label" : 
+              { "value" : "\"France\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Other country\"" },
+              "label" : 
+              { "value" : "\"Other country\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Other planet\"" } ],
+              "label" : 
+              { "value" : "\"Other planet\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Car\"" },
+              "label" : 
+              { "value" : "\"Car\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvm4qg",
@@ -1681,7 +2187,9 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Bike\"" },
+              "label" : 
+              { "value" : "\"Bike\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvebem",
@@ -1727,7 +2235,9 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Skateboard\"" },
+              "label" : 
+              { "value" : "\"Skateboard\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewv62xx",
@@ -1773,7 +2283,9 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Plane\"" },
+              "label" : 
+              { "value" : "\"Plane\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxBoolean",
               "id" : "j6p2lwuj-QOP-kewvjcck",
@@ -1820,7 +2332,9 @@
       { "id" : "j6qfx9qe",
         "componentType" : "Sequence",
         "page" : "28",
-        "label" : "\"V - Favourite characters (dynamic table)\"",
+        "label" : 
+        { "value" : "\"V - Favourite characters (dynamic table)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1829,14 +2343,18 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6qg8rc6",
         "componentType" : "Table",
         "mandatory" : false,
         "page" : "29",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+        "label" : 
+        { "value" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1845,7 +2363,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "FAVOURITE_CHAR1",
           "FAVOURITE_CHAR2",
@@ -1887,13 +2407,19 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "\"Name\"" },
+              "label" : 
+              { "value" : "\"Name\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Age\"" },
+              "label" : 
+              { "value" : "\"Age\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Member of the Simpsons family\"" } ],
+              "label" : 
+              { "value" : "\"Member of the Simpsons family\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "componentType" : "Textarea",
@@ -1917,13 +2443,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_1_3" },
               "bindingDependencies" : 
@@ -1951,13 +2483,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_2_3" },
               "bindingDependencies" : 
@@ -1985,13 +2523,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_3_3" },
               "bindingDependencies" : 
@@ -2019,13 +2563,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_4_3" },
               "bindingDependencies" : 
@@ -2053,13 +2603,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_5_3" },
               "bindingDependencies" : 
@@ -2087,13 +2643,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_6_3" },
               "bindingDependencies" : 
@@ -2121,13 +2683,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_7_3" },
               "bindingDependencies" : 
@@ -2155,13 +2723,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_8_3" },
               "bindingDependencies" : 
@@ -2189,13 +2763,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_9_3" },
               "bindingDependencies" : 
@@ -2223,13 +2803,19 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Yes\"" },
+                  "label" : 
+                  { "value" : "\"Yes\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"No\"" },
+                  "label" : 
+                  { "value" : "\"No\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Other\"" } ],
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FAVOURITE_CHAR3_10_3" },
               "bindingDependencies" : 
@@ -2240,7 +2826,9 @@
         "mandatory" : false,
         "page" : "30",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+        "label" : 
+        { "value" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2249,7 +2837,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "FEELCHAREV1",
           "FEELCHAREV2",
@@ -2259,20 +2849,28 @@
         [ 
           [ 
             { "value" : "1",
-              "label" : "\"Jay\"" },
+              "label" : 
+              { "value" : "\"Jay\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq76emy",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV1" },
               "bindingDependencies" : 
@@ -2280,20 +2878,28 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Bart\"" },
+              "label" : 
+              { "value" : "\"Bart\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq6zv60",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV2" },
               "bindingDependencies" : 
@@ -2301,20 +2907,28 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Krusty the clown\"" },
+              "label" : 
+              { "value" : "\"Krusty the clown\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq7bgk3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV3" },
               "bindingDependencies" : 
@@ -2322,20 +2936,28 @@
           
           [ 
             { "value" : "O",
-              "label" : "\"Other\"" },
+              "label" : 
+              { "value" : "\"Other\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "CheckboxOne",
               "id" : "jvxux0mi-QOP-kiq6ync3",
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Up\"" },
+                  "label" : 
+                  { "value" : "\"Up\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Down\"" },
+                  "label" : 
+                  { "value" : "\"Down\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "3",
-                  "label" : "\"Steady\"" } ],
+                  "label" : 
+                  { "value" : "\"Steady\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "FEELCHAREV4" },
               "bindingDependencies" : 
@@ -2346,7 +2968,9 @@
         "mandatory" : false,
         "page" : "31",
         "positioning" : "HORIZONTAL",
-        "label" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+        "label" : 
+        { "value" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2355,7 +2979,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "LEAVDURATION11",
           "LEAVDURATION12",
@@ -2371,17 +2997,25 @@
         [ 
           [ 
             { "headerCell" : true,
-              "label" : "" },
+              "label" : 
+              { "value" : "",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Days\"" },
+              "label" : 
+              { "value" : "\"Days\"",
+                "type" : "VTL|MD" } },
             
             { "headerCell" : true,
-              "label" : "\"Unit\"" } ],
+              "label" : 
+              { "value" : "\"Unit\"",
+                "type" : "VTL|MD" } } ],
           
           [ 
             { "value" : "1",
-              "label" : "\"Leave with pay\"" },
+              "label" : 
+              { "value" : "\"Leave with pay\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2398,10 +3032,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION12" },
               "bindingDependencies" : 
@@ -2409,7 +3047,9 @@
           
           [ 
             { "value" : "2",
-              "label" : "\"Public holiday\"" },
+              "label" : 
+              { "value" : "\"Public holiday\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2426,10 +3066,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION22" },
               "bindingDependencies" : 
@@ -2437,7 +3081,9 @@
           
           [ 
             { "value" : "3",
-              "label" : "\"Sick leave\"" },
+              "label" : 
+              { "value" : "\"Sick leave\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2454,10 +3100,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION32" },
               "bindingDependencies" : 
@@ -2465,7 +3115,9 @@
           
           [ 
             { "value" : "4",
-              "label" : "\"Maternity\/paternity leave\"" },
+              "label" : 
+              { "value" : "\"Maternity\/paternity leave\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2482,10 +3134,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION42" },
               "bindingDependencies" : 
@@ -2493,7 +3149,9 @@
           
           [ 
             { "value" : "5",
-              "label" : "\"Other type\"" },
+              "label" : 
+              { "value" : "\"Other type\"",
+                "type" : "VTL|MD" } },
             
             { "componentType" : "InputNumber",
               "min" : 0,
@@ -2510,10 +3168,14 @@
               "options" : 
               [ 
                 { "value" : "1",
-                  "label" : "\"Working Days\"" },
+                  "label" : 
+                  { "value" : "\"Working Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "value" : "2",
-                  "label" : "\"Calendar days\"" } ],
+                  "label" : 
+                  { "value" : "\"Calendar days\"",
+                    "type" : "VTL|MD" } } ],
               "response" : 
               { "name" : "LEAVDURATION52" },
               "bindingDependencies" : 
@@ -2522,7 +3184,9 @@
       { "id" : "kiq5mr0b",
         "componentType" : "Sequence",
         "page" : "32",
-        "label" : "\"VI - Favourite characters (Loop)\"",
+        "label" : 
+        { "value" : "\"VI - Favourite characters (Loop)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2531,7 +3195,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "kiq612ky",
         "componentType" : "InputNumber",
@@ -2540,7 +3206,9 @@
         "min" : 0,
         "max" : 20,
         "decimals" : 0,
-        "label" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+        "label" : 
+        { "value" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2549,7 +3217,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NB_CHAR" ],
         "response" : 
@@ -2559,7 +3229,9 @@
         "componentType" : "Loop",
         "page" : "34",
         "paginatedLoop" : false,
-        "label" : "\"Add a character\"",
+        "label" : 
+        { "value" : "\"Add a character\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2568,7 +3240,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "NAME_CHAR",
           "AGE_CHAR" ],
@@ -2578,7 +3252,9 @@
             "componentType" : "Subsequence",
             "page" : "34",
             "goToPage" : "34",
-            "label" : "\"Description of each character\"",
+            "label" : 
+            { "value" : "\"Description of each character\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2587,18 +3263,24 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } } },
           
           { "id" : "kiq66gtw",
             "componentType" : "Input",
             "mandatory" : false,
             "page" : "34",
             "maxLength" : 30,
-            "label" : "\"➡ 2. What is the first name of this character?\"",
+            "label" : 
+            { "value" : "\"➡ 2. What is the first name of this character?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2607,11 +3289,15 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR" ],
             "response" : 
@@ -2624,7 +3310,9 @@
             "min" : 0,
             "max" : 120,
             "decimals" : 0,
-            "label" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+            "label" : 
+            { "value" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2633,11 +3321,15 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "kiq5u8d5",
                 "page" : "34",
-                "label" : "\"Description of each character\"" } },
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "AGE_CHAR" ],
             "response" : 
@@ -2666,7 +3358,9 @@
           { "id" : "kiq5xw5p",
             "componentType" : "Sequence",
             "page" : "35.1",
-            "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+            "label" : 
+            { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2675,7 +3369,9 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR" ] },
           
@@ -2683,7 +3379,9 @@
             "componentType" : "CheckboxOne",
             "mandatory" : false,
             "page" : "35.2",
-            "label" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+            "label" : 
+            { "value" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2692,17 +3390,23 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR",
               "FAVCHAR" ],
             "options" : 
             [ 
               { "value" : "1",
-                "label" : "\"Yes\"" },
+                "label" : 
+                { "value" : "\"Yes\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "0",
-                "label" : "\"No\"" } ],
+                "label" : 
+                { "value" : "\"No\"",
+                  "type" : "VTL|MD" } } ],
             "response" : 
             { "name" : "FAVCHAR" } },
           
@@ -2711,7 +3415,9 @@
             "mandatory" : false,
             "page" : "35.3",
             "maxLength" : 255,
-            "label" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+            "label" : 
+            { "value" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2720,7 +3426,9 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR",
               "MEMORY_CHAR" ],
@@ -2730,28 +3438,36 @@
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
         "page" : "36",
-        "label" : "\"VIII - Comment\"",
+        "label" : 
+        { "value" : "\"VIII - Comment\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
             "page" : "36",
-            "label" : "\"VIII - Comment\"" } } },
+            "label" : 
+            { "value" : "\"VIII - Comment\"",
+              "type" : "VTL|MD" } } } },
       
       { "id" : "j6z0z3us",
         "componentType" : "Textarea",
         "mandatory" : false,
         "page" : "37",
         "maxLength" : 255,
-        "label" : "\"➡ 1. Do you have any comment about the survey?\"",
+        "label" : 
+        { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
             "page" : "36",
-            "label" : "\"VIII - Comment\"" } },
+            "label" : 
+            { "value" : "\"VIII - Comment\"",
+              "type" : "VTL|MD" } } },
         "bindingDependencies" : 
         [ "SURVEY_COMMENT" ],
         "response" : 

--- a/src/test/resources/examples/xmlh-2-jsonh/out.json
+++ b/src/test/resources/examples/xmlh-2-jsonh/out.json
@@ -3,7 +3,7 @@
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
     "lunaticModelVersion" : "2.2.11",
-    "generatingDate" : "11-03-2022 11:39:17",
+    "generatingDate" : "15-03-2022 13:41:50",
     "pagination" : "question",
     "maxPage" : "37",
     "label" : 
@@ -26,7 +26,8 @@
             { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
@@ -45,7 +46,8 @@
             { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
               "type" : "VTL|MD" },
             "conditionFilter" : 
-            { "value" : "true" },
+            { "value" : "true",
+              "type" : "VTL|MD" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
@@ -74,7 +76,8 @@
                 { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
                   "type" : "VTL|MD" } } ],
             "conditionFilter" : 
-            { "value" : "true" },
+            { "value" : "true",
+              "type" : "VTL|MD" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
@@ -95,7 +98,8 @@
             { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
               "type" : "VTL|MD" },
             "conditionFilter" : 
-            { "value" : "true" },
+            { "value" : "true",
+              "type" : "VTL|MD" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
@@ -112,6 +116,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -139,6 +144,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -171,6 +177,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -210,6 +217,7 @@
                       "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -249,6 +257,7 @@
                       "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -289,6 +298,7 @@
                       "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -322,6 +332,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -355,6 +366,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -388,6 +400,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -421,6 +434,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -454,6 +468,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -491,6 +506,7 @@
               "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -519,6 +535,7 @@
                   "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -566,6 +583,7 @@
                   "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -610,6 +628,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -698,6 +717,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -725,6 +745,7 @@
                   "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -787,6 +808,7 @@
                   "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -909,6 +931,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -1031,6 +1054,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -1251,6 +1275,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -1270,6 +1295,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -1297,6 +1323,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -1490,6 +1517,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -1787,6 +1815,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -1814,6 +1843,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -2032,6 +2062,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -2067,6 +2098,7 @@
                       "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -2345,6 +2377,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -2366,6 +2399,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -2410,8 +2444,12 @@
               "FAVOURITE_CHAR2_10_2",
               "FAVOURITE_CHAR3_10_3" ],
             "lines" : 
-            { "min" : 1,
-              "max" : 10 },
+            { "min" : 
+              { "value" : "1",
+                "type" : "VTL|MD" },
+              "max" : 
+              { "value" : "10",
+                "type" : "VTL|MD" } },
             "cells" : 
             [ 
               [ 
@@ -2840,6 +2878,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -2982,6 +3021,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3198,6 +3238,7 @@
           "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "hierarchy" : 
@@ -3221,6 +3262,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3244,6 +3286,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3267,6 +3310,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -3294,6 +3338,7 @@
                       "type" : "VTL|MD" },
                     "conditionFilter" : 
                     { "value" : "(not(cast(READY,integer)  <>  1))",
+                      "type" : "VTL|MD",
                       "bindingDependencies" : 
                       [ "READY" ] },
                     "hierarchy" : 
@@ -3326,6 +3371,7 @@
                       "type" : "VTL|MD" },
                     "conditionFilter" : 
                     { "value" : "(not(cast(READY,integer)  <>  1))",
+                      "type" : "VTL|MD",
                       "bindingDependencies" : 
                       [ "READY" ] },
                     "hierarchy" : 
@@ -3350,11 +3396,11 @@
         "componentType" : "Loop",
         "page" : "35",
         "maxPage" : "3",
-        "iterations" : "count(NAME_CHAR)",
         "depth" : 1,
         "paginatedLoop" : true,
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
+          "type" : "VTL|MD",
           "bindingDependencies" : 
           [ "READY" ] },
         "bindingDependencies" : 
@@ -3374,6 +3420,7 @@
               "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
+              "type" : "VTL|MD",
               "bindingDependencies" : 
               [ "READY" ] },
             "hierarchy" : 
@@ -3396,6 +3443,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -3432,6 +3480,7 @@
                   "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
+                  "type" : "VTL|MD",
                   "bindingDependencies" : 
                   [ "READY" ] },
                 "hierarchy" : 
@@ -3445,7 +3494,10 @@
                 [ "NAME_CHAR",
                   "MEMORY_CHAR" ],
                 "response" : 
-                { "name" : "MEMORY_CHAR" } } ] } ] },
+                { "name" : "MEMORY_CHAR" } } ] } ],
+        "iterations" : 
+        { "value" : "count(NAME_CHAR)",
+          "type" : "VTL|MD" } },
       
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
@@ -3454,7 +3506,8 @@
         { "value" : "\"VIII - Comment\"",
           "type" : "VTL|MD" },
         "conditionFilter" : 
-        { "value" : "true" },
+        { "value" : "true",
+          "type" : "VTL|MD" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
@@ -3473,7 +3526,8 @@
             { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
               "type" : "VTL|MD" },
             "conditionFilter" : 
-            { "value" : "true" },
+            { "value" : "true",
+              "type" : "VTL|MD" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6z12s2d",

--- a/src/test/resources/examples/xmlh-2-jsonh/out.json
+++ b/src/test/resources/examples/xmlh-2-jsonh/out.json
@@ -2,30 +2,38 @@
   { "id" : "i6vwi2506qf2mms",
     "modele" : "SIMPSONS",
     "enoCoreVersion" : "2.2.8",
-    "lunaticModelVersion" : "2.1.2",
-    "generatingDate" : "28-06-2021 17:07:23",
+    "lunaticModelVersion" : "2.2.11",
+    "generatingDate" : "11-03-2022 11:39:17",
     "pagination" : "question",
     "maxPage" : "37",
-    "label" : "Questionnaire SIMPSONS 20201215",
+    "label" : 
+    { "value" : "Questionnaire SIMPSONS 20201215",
+      "type" : "VTL|MD" },
     "components" : 
     [ 
       { "id" : "j6p0ti5h",
         "componentType" : "Sequence",
         "page" : "1",
-        "label" : "\"I - Introduction\"",
+        "label" : 
+        { "value" : "\"I - Introduction\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j6p0ti5h-d1",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"" } ],
+            "label" : 
+            { "value" : "\"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6p0ti5h",
             "page" : "1",
-            "label" : "\"I - Introduction\"" } },
+            "label" : 
+            { "value" : "\"I - Introduction\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j6p3dkx6",
@@ -33,14 +41,18 @@
             "mandatory" : true,
             "page" : "2",
             "maxLength" : 500,
-            "label" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+            "label" : 
+            { "value" : "\"➡ 1. Before starting, do you have any comments about the Simpsons family?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "true" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
                 "page" : "1",
-                "label" : "\"I - Introduction\"" } },
+                "label" : 
+                { "value" : "\"I - Introduction\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "COMMENT" ],
             "response" : 
@@ -50,20 +62,26 @@
             "componentType" : "CheckboxBoolean",
             "mandatory" : false,
             "page" : "3",
-            "label" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+            "label" : 
+            { "value" : "\"➡ 2. If you agree to answer this questionnaire, please check the box\"",
+              "type" : "VTL|MD" },
             "declarations" : 
             [ 
               { "id" : "j6p0np9q-kir6xl1e",
                 "declarationType" : "COMMENT",
                 "position" : "AFTER_QUESTION_TEXT",
-                "label" : "\"If not, this is unfortunately the end of this questionnaire.\"" } ],
+                "label" : 
+                { "value" : "\"If not, this is unfortunately the end of this questionnaire.\"",
+                  "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "true" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
                 "page" : "1",
-                "label" : "\"I - Introduction\"" } },
+                "label" : 
+                { "value" : "\"I - Introduction\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "READY" ],
             "response" : 
@@ -73,19 +91,25 @@
             "componentType" : "FilterDescription",
             "page" : "3",
             "filterDescription" : false,
-            "label" : "\"If you are not ready, please go to the end of the questionnaire\"",
+            "label" : 
+            { "value" : "\"If you are not ready, please go to the end of the questionnaire\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "true" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6p0ti5h",
                 "page" : "1",
-                "label" : "\"I - Introduction\"" } } },
+                "label" : 
+                { "value" : "\"I - Introduction\"",
+                  "type" : "VTL|MD" } } } },
           
           { "id" : "j6p0s7o5",
             "componentType" : "Subsequence",
             "goToPage" : "4",
-            "label" : "\"General knowledge of the series\"",
+            "label" : 
+            { "value" : "\"General knowledge of the series\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -94,11 +118,15 @@
             { "sequence" : 
               { "id" : "j6p0ti5h",
                 "page" : "1",
-                "label" : "\"I - Introduction\"" },
+                "label" : 
+                { "value" : "\"I - Introduction\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "j6p0s7o5",
                 "page" : "4",
-                "label" : "\"General knowledge of the series\"" } },
+                "label" : 
+                { "value" : "\"General knowledge of the series\"",
+                  "type" : "VTL|MD" } } },
             "components" : 
             [ 
               { "id" : "j3343qhx",
@@ -106,7 +134,9 @@
                 "mandatory" : false,
                 "page" : "4",
                 "maxLength" : 30,
-                "label" : "\"➡ 3. Who is the producer?\"",
+                "label" : 
+                { "value" : "\"➡ 3. Who is the producer?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -115,11 +145,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "PRODUCER" ],
                 "response" : 
@@ -132,7 +166,9 @@
                 "min" : 0,
                 "max" : 99,
                 "decimals" : 0,
-                "label" : "\"➡ 4. What is the current season number?\"",
+                "label" : 
+                { "value" : "\"➡ 4. What is the current season number?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -141,11 +177,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "SEASON_NUMBER" ],
                 "response" : 
@@ -157,13 +197,17 @@
                 "page" : "6",
                 "min" : "1900-01-01",
                 "max" : "format-date(current-date(),'[Y0001]-[M01]-[D01]')",
-                "label" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+                "label" : 
+                { "value" : "\"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)\"",
+                  "type" : "VTL|MD" },
                 "declarations" : 
                 [ 
                   { "id" : "kiq71eoi-kiq7dsy2",
                     "declarationType" : "INSTRUCTION",
                     "position" : "AFTER_QUESTION_TEXT",
-                    "label" : "\"Please answer with YYYY-MM-DD format\"" } ],
+                    "label" : 
+                    { "value" : "\"Please answer with YYYY-MM-DD format\"",
+                      "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -172,11 +216,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DATEFIRST" ],
                 "dateFormat" : "YYYY-MM-DD",
@@ -188,13 +236,17 @@
                 "mandatory" : false,
                 "page" : "7",
                 "min" : "1980-05",
-                "label" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+                "label" : 
+                { "value" : "\"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)\"",
+                  "type" : "VTL|MD" },
                 "declarations" : 
                 [ 
                   { "id" : "k5nvty2o-k5nvxld8",
                     "declarationType" : "COMMENT",
                     "position" : "AFTER_QUESTION_TEXT",
-                    "label" : "\"Please answer with YYYY-MM format\"" } ],
+                    "label" : 
+                    { "value" : "\"Please answer with YYYY-MM format\"",
+                      "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -203,11 +255,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DATEYYYYMM" ],
                 "dateFormat" : "YYYY-MM",
@@ -220,13 +276,17 @@
                 "page" : "8",
                 "min" : "1900",
                 "max" : "year-from-date(current-date())",
-                "label" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+                "label" : 
+                { "value" : "\"➡ 7. When was the first episode of the Simpsons? (format YYYY)\"",
+                  "type" : "VTL|MD" },
                 "declarations" : 
                 [ 
                   { "id" : "k5nw1fir-k5nvmx3n",
                     "declarationType" : "COMMENT",
                     "position" : "AFTER_QUESTION_TEXT",
-                    "label" : "\"Please answer with YYYY format\"" } ],
+                    "label" : 
+                    { "value" : "\"Please answer with YYYY format\"",
+                      "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -235,11 +295,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DATEYYYY" ],
                 "dateFormat" : "YYYY",
@@ -253,7 +317,9 @@
                 "min" : 0,
                 "max" : 70,
                 "decimals" : 2,
-                "label" : "\"➡ 8. How long does an episode last?\"",
+                "label" : 
+                { "value" : "\"➡ 8. How long does an episode last?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -262,11 +328,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DURATIONH" ],
                 "unit" : "heures",
@@ -280,7 +350,9 @@
                 "min" : 0,
                 "max" : 366,
                 "decimals" : 1,
-                "label" : "\"➡ 9. How long does it take to write a new episode?\"",
+                "label" : 
+                { "value" : "\"➡ 9. How long does it take to write a new episode?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -289,11 +361,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DURATIOND" ],
                 "unit" : "jours",
@@ -307,7 +383,9 @@
                 "min" : 0,
                 "max" : 12,
                 "decimals" : 0,
-                "label" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+                "label" : 
+                { "value" : "\"➡ 10. How long will it take you to watch all the existing episodes?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -316,11 +394,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DURATIONM" ],
                 "unit" : "mois",
@@ -334,7 +416,9 @@
                 "min" : 0,
                 "max" : 100,
                 "decimals" : 0,
-                "label" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+                "label" : 
+                { "value" : "\"➡ 11. For how long have you known the Simpsons family?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -343,11 +427,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "DURATIONY" ],
                 "unit" : "années",
@@ -361,7 +449,9 @@
                 "min" : 0,
                 "max" : 99,
                 "decimals" : 1,
-                "label" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+                "label" : 
+                { "value" : "\"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -370,11 +460,15 @@
                 { "sequence" : 
                   { "id" : "j6p0ti5h",
                     "page" : "1",
-                    "label" : "\"I - Introduction\"" },
+                    "label" : 
+                    { "value" : "\"I - Introduction\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6p0s7o5",
                     "page" : "4",
-                    "label" : "\"General knowledge of the series\"" } },
+                    "label" : 
+                    { "value" : "\"General knowledge of the series\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "AUDIENCE_SHARE" ],
                 "unit" : "%",
@@ -384,13 +478,17 @@
       { "id" : "j3341528",
         "componentType" : "Sequence",
         "page" : "14",
-        "label" : "\"II - Simpsons’ city\"",
+        "label" : 
+        { "value" : "\"II - Simpsons’ city\"",
+          "type" : "VTL|MD" },
         "declarations" : 
         [ 
           { "id" : "j3341528-d2",
             "declarationType" : "COMMENT",
             "position" : "AFTER_QUESTION_TEXT",
-            "label" : "\"This module asks about your general knowledge of the Simpsons city\"" } ],
+            "label" : 
+            { "value" : "\"This module asks about your general knowledge of the Simpsons city\"",
+              "type" : "VTL|MD" } } ],
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -399,20 +497,26 @@
         { "sequence" : 
           { "id" : "j3341528",
             "page" : "14",
-            "label" : "\"II - Simpsons’ city\"" } },
+            "label" : 
+            { "value" : "\"II - Simpsons’ city\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j3343clt",
             "componentType" : "Radio",
             "mandatory" : true,
             "page" : "15",
-            "label" : "\"➡ 1. In which city do the Simpsons reside?\"",
+            "label" : 
+            { "value" : "\"➡ 1. In which city do the Simpsons reside?\"",
+              "type" : "VTL|MD" },
             "declarations" : 
             [ 
               { "id" : "j3343clt-d3",
                 "declarationType" : "INSTRUCTION",
                 "position" : "AFTER_QUESTION_TEXT",
-                "label" : "\"One possible answer\"" } ],
+                "label" : 
+                { "value" : "\"One possible answer\"",
+                  "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -421,19 +525,27 @@
             { "sequence" : 
               { "id" : "j3341528",
                 "page" : "14",
-                "label" : "\"II - Simpsons’ city\"" } },
+                "label" : 
+                { "value" : "\"II - Simpsons’ city\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "CITY" ],
             "options" : 
             [ 
               { "value" : "00001",
-                "label" : "\"Springfield\"" },
+                "label" : 
+                { "value" : "\"Springfield\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "00002",
-                "label" : "\"Shelbyville\"" },
+                "label" : 
+                { "value" : "\"Shelbyville\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "03",
-                "label" : "\"Seinfeld\"" } ],
+                "label" : 
+                { "value" : "\"Seinfeld\"",
+                  "type" : "VTL|MD" } } ],
             "response" : 
             { "name" : "CITY" } },
           
@@ -441,13 +553,17 @@
             "componentType" : "CheckboxOne",
             "mandatory" : false,
             "page" : "16",
-            "label" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+            "label" : 
+            { "value" : "\"➡ 2. Who is the Simpsons city mayor?\"",
+              "type" : "VTL|MD" },
             "declarations" : 
             [ 
               { "id" : "j6qdfhvw-d4",
                 "declarationType" : "INSTRUCTION",
                 "position" : "AFTER_QUESTION_TEXT",
-                "label" : "\"Only one possible answer\"" } ],
+                "label" : 
+                { "value" : "\"Only one possible answer\"",
+                  "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -456,22 +572,32 @@
             { "sequence" : 
               { "id" : "j3341528",
                 "page" : "14",
-                "label" : "\"II - Simpsons’ city\"" } },
+                "label" : 
+                { "value" : "\"II - Simpsons’ city\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "MAYOR" ],
             "options" : 
             [ 
               { "value" : "1",
-                "label" : "\"Constance Harm\"" },
+                "label" : 
+                { "value" : "\"Constance Harm\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "2",
-                "label" : "\"Timothy Lovejoy\"" },
+                "label" : 
+                { "value" : "\"Timothy Lovejoy\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "3",
-                "label" : "\"Joe Quimby\"" },
+                "label" : 
+                { "value" : "\"Joe Quimby\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "OT",
-                "label" : "\"Other name\"" } ],
+                "label" : 
+                { "value" : "\"Other name\"",
+                  "type" : "VTL|MD" } } ],
             "response" : 
             { "name" : "MAYOR" } },
           
@@ -479,7 +605,9 @@
             "componentType" : "Dropdown",
             "mandatory" : false,
             "page" : "17",
-            "label" : "\"➡ 3. In which state do The Simpsons reside?\"",
+            "label" : 
+            { "value" : "\"➡ 3. In which state do The Simpsons reside?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -488,56 +616,86 @@
             { "sequence" : 
               { "id" : "j3341528",
                 "page" : "14",
-                "label" : "\"II - Simpsons’ city\"" } },
+                "label" : 
+                { "value" : "\"II - Simpsons’ city\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "STATE" ],
             "options" : 
             [ 
               { "value" : "1",
-                "label" : "\"Washington\"" },
+                "label" : 
+                { "value" : "\"Washington\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "2",
-                "label" : "\"Kentucky\"" },
+                "label" : 
+                { "value" : "\"Kentucky\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "3",
-                "label" : "\"Ohio\"" },
+                "label" : 
+                { "value" : "\"Ohio\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "4",
-                "label" : "\"Maine\"" },
+                "label" : 
+                { "value" : "\"Maine\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "5",
-                "label" : "\"North Dakota\"" },
+                "label" : 
+                { "value" : "\"North Dakota\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "6",
-                "label" : "\"Florida\"" },
+                "label" : 
+                { "value" : "\"Florida\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "7",
-                "label" : "\"North Takoma\"" },
+                "label" : 
+                { "value" : "\"North Takoma\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "8",
-                "label" : "\"California\"" },
+                "label" : 
+                { "value" : "\"California\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "9",
-                "label" : "\"Texas\"" },
+                "label" : 
+                { "value" : "\"Texas\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "10",
-                "label" : "\"Massachusetts\"" },
+                "label" : 
+                { "value" : "\"Massachusetts\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "11",
-                "label" : "\"Nevada\"" },
+                "label" : 
+                { "value" : "\"Nevada\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "12",
-                "label" : "\"Illinois\"" },
+                "label" : 
+                { "value" : "\"Illinois\"",
+                  "type" : "VTL|MD" } },
               
               { "value" : "13",
-                "label" : "\"Not in any state, you fool!\"" } ],
+                "label" : 
+                { "value" : "\"Not in any state, you fool!\"",
+                  "type" : "VTL|MD" } } ],
             "response" : 
             { "name" : "STATE" } } ] },
       
       { "id" : "j6qe0h9q",
         "componentType" : "Sequence",
         "page" : "18",
-        "label" : "\"III - Characters\"",
+        "label" : 
+        { "value" : "\"III - Characters\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -546,19 +704,25 @@
         { "sequence" : 
           { "id" : "j6qe0h9q",
             "page" : "18",
-            "label" : "\"III - Characters\"" } },
+            "label" : 
+            { "value" : "\"III - Characters\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j334akov",
             "componentType" : "CheckboxGroup",
             "page" : "19",
-            "label" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+            "label" : 
+            { "value" : "\"➡ 1. What are the pet names that the Simpsons family had?\"",
+              "type" : "VTL|MD" },
             "declarations" : 
             [ 
               { "id" : "j334akov-d5",
                 "declarationType" : "INSTRUCTION",
                 "position" : "AFTER_QUESTION_TEXT",
-                "label" : "\"Several possible answers\"" } ],
+                "label" : 
+                { "value" : "\"Several possible answers\"",
+                  "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -567,7 +731,9 @@
             { "sequence" : 
               { "id" : "j6qe0h9q",
                 "page" : "18",
-                "label" : "\"III - Characters\"" } },
+                "label" : 
+                { "value" : "\"III - Characters\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "PET1",
               "PET2",
@@ -576,22 +742,30 @@
             "responses" : 
             [ 
               { "id" : "j334akov-QOP-khokqjtw",
-                "label" : "\"Santa’s Little Helper\"",
+                "label" : 
+                { "value" : "\"Santa’s Little Helper\"",
+                  "type" : "VTL|MD" },
                 "response" : 
                 { "name" : "PET1" } },
               
               { "id" : "j334akov-QOP-khokur7a",
-                "label" : "\"Snowball I\"",
+                "label" : 
+                { "value" : "\"Snowball I\"",
+                  "type" : "VTL|MD" },
                 "response" : 
                 { "name" : "PET2" } },
               
               { "id" : "j334akov-QOP-khol82ux",
-                "label" : "\"Coltrane\"",
+                "label" : 
+                { "value" : "\"Coltrane\"",
+                  "type" : "VTL|MD" },
                 "response" : 
                 { "name" : "PET3" } },
               
               { "id" : "j334akov-QOP-khokqee5",
-                "label" : "\"Other name\"",
+                "label" : 
+                { "value" : "\"Other name\"",
+                  "type" : "VTL|MD" },
                 "response" : 
                 { "name" : "PET4" } } ] },
           
@@ -600,13 +774,17 @@
             "mandatory" : false,
             "page" : "20",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+            "label" : 
+            { "value" : "\"➡ 2. Does Jay like the following ice cream flavours?\"",
+              "type" : "VTL|MD" },
             "declarations" : 
             [ 
               { "id" : "d12-SI",
                 "declarationType" : "STATEMENT",
                 "position" : "BEFORE_QUESTION_TEXT",
-                "label" : "\"Now we are going to know if you think that Jay is a gluton.\"" } ],
+                "label" : 
+                { "value" : "\"Now we are going to know if you think that Jay is a gluton.\"",
+                  "type" : "VTL|MD" } } ],
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -615,7 +793,9 @@
             { "sequence" : 
               { "id" : "j6qe0h9q",
                 "page" : "18",
-                "label" : "\"III - Characters\"" } },
+                "label" : 
+                { "value" : "\"III - Characters\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "ICE_FLAVOUR1",
               "ICE_FLAVOUR2",
@@ -625,17 +805,23 @@
             [ 
               [ 
                 { "value" : "1",
-                  "label" : "\"Vanilla\"" },
+                  "label" : 
+                  { "value" : "\"Vanilla\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Radio",
                   "id" : "j6p29i81-QOP-kiq5w99y",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "ICE_FLAVOUR1" },
                   "bindingDependencies" : 
@@ -643,17 +829,23 @@
               
               [ 
                 { "value" : "2",
-                  "label" : "\"Strawberry\"" },
+                  "label" : 
+                  { "value" : "\"Strawberry\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Radio",
                   "id" : "j6p29i81-QOP-kiq5ummf",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "ICE_FLAVOUR2" },
                   "bindingDependencies" : 
@@ -661,17 +853,23 @@
               
               [ 
                 { "value" : "3",
-                  "label" : "\"Apple\"" },
+                  "label" : 
+                  { "value" : "\"Apple\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Radio",
                   "id" : "j6p29i81-QOP-kiq5mry5",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "ICE_FLAVOUR3" },
                   "bindingDependencies" : 
@@ -679,17 +877,23 @@
               
               [ 
                 { "value" : "OT",
-                  "label" : "\"Other flavour\"" },
+                  "label" : 
+                  { "value" : "\"Other flavour\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Radio",
                   "id" : "j6p29i81-QOP-kiq5lkr8",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "ICE_FLAVOUR4" },
                   "bindingDependencies" : 
@@ -700,7 +904,9 @@
             "mandatory" : false,
             "page" : "21",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+            "label" : 
+            { "value" : "\"➡ 3. Which character works in the nuclear power plant?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -709,7 +915,9 @@
             { "sequence" : 
               { "id" : "j6qe0h9q",
                 "page" : "18",
-                "label" : "\"III - Characters\"" } },
+                "label" : 
+                { "value" : "\"III - Characters\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NUCLEAR_CHARACTER1",
               "NUCLEAR_CHARACTER2",
@@ -719,17 +927,23 @@
             [ 
               [ 
                 { "value" : "1",
-                  "label" : "\"Charles Montgomery Burns\"" },
+                  "label" : 
+                  { "value" : "\"Charles Montgomery Burns\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Dropdown",
                   "id" : "j6qefnga-QOP-kewva8xg",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "NUCLEAR_CHARACTER1" },
                   "bindingDependencies" : 
@@ -737,17 +951,23 @@
               
               [ 
                 { "value" : "2",
-                  "label" : "\"Carl Carlson\"" },
+                  "label" : 
+                  { "value" : "\"Carl Carlson\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Dropdown",
                   "id" : "j6qefnga-QOP-kewvj0ad",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "NUCLEAR_CHARACTER2" },
                   "bindingDependencies" : 
@@ -755,17 +975,23 @@
               
               [ 
                 { "value" : "3",
-                  "label" : "\"Otto Mann\"" },
+                  "label" : 
+                  { "value" : "\"Otto Mann\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Dropdown",
                   "id" : "j6qefnga-QOP-kewveltm",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "NUCLEAR_CHARACTER3" },
                   "bindingDependencies" : 
@@ -773,17 +999,23 @@
               
               [ 
                 { "value" : "4",
-                  "label" : "\"Lenny Leonard\"" },
+                  "label" : 
+                  { "value" : "\"Lenny Leonard\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "Dropdown",
                   "id" : "j6qefnga-QOP-kewvgax4",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "0",
-                      "label" : "\"No\"" } ],
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "NUCLEAR_CHARACTER4" },
                   "bindingDependencies" : 
@@ -794,7 +1026,9 @@
             "mandatory" : false,
             "page" : "22",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 4. In which city each character was born?\"",
+            "label" : 
+            { "value" : "\"➡ 4. In which city each character was born?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -803,7 +1037,9 @@
             { "sequence" : 
               { "id" : "j6qe0h9q",
                 "page" : "18",
-                "label" : "\"III - Characters\"" } },
+                "label" : 
+                { "value" : "\"III - Characters\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "BIRTH_CHARACTER1",
               "BIRTH_CHARACTER2",
@@ -814,26 +1050,38 @@
             [ 
               [ 
                 { "value" : "1",
-                  "label" : "\"Selma Bouvier\"" },
+                  "label" : 
+                  { "value" : "\"Selma Bouvier\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "j6yzoc6g-QOP-kewvjvcs",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Albuquerque\"" },
+                      "label" : 
+                      { "value" : "\"Albuquerque\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Springfield\"" },
+                      "label" : 
+                      { "value" : "\"Springfield\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Portland\"" },
+                      "label" : 
+                      { "value" : "\"Portland\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "4",
-                      "label" : "\"Shelbyville\"" },
+                      "label" : 
+                      { "value" : "\"Shelbyville\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "5",
-                      "label" : "\"Dagstuhl\"" } ],
+                      "label" : 
+                      { "value" : "\"Dagstuhl\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "BIRTH_CHARACTER1" },
                   "bindingDependencies" : 
@@ -841,26 +1089,38 @@
               
               [ 
                 { "value" : "2",
-                  "label" : "\"Kent Brockman\"" },
+                  "label" : 
+                  { "value" : "\"Kent Brockman\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "j6yzoc6g-QOP-kewvhoda",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Albuquerque\"" },
+                      "label" : 
+                      { "value" : "\"Albuquerque\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Springfield\"" },
+                      "label" : 
+                      { "value" : "\"Springfield\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Portland\"" },
+                      "label" : 
+                      { "value" : "\"Portland\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "4",
-                      "label" : "\"Shelbyville\"" },
+                      "label" : 
+                      { "value" : "\"Shelbyville\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "5",
-                      "label" : "\"Dagstuhl\"" } ],
+                      "label" : 
+                      { "value" : "\"Dagstuhl\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "BIRTH_CHARACTER2" },
                   "bindingDependencies" : 
@@ -868,26 +1128,38 @@
               
               [ 
                 { "value" : "3",
-                  "label" : "\"Milhouse Van Houten\"" },
+                  "label" : 
+                  { "value" : "\"Milhouse Van Houten\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "j6yzoc6g-QOP-kewv64s5",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Albuquerque\"" },
+                      "label" : 
+                      { "value" : "\"Albuquerque\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Springfield\"" },
+                      "label" : 
+                      { "value" : "\"Springfield\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Portland\"" },
+                      "label" : 
+                      { "value" : "\"Portland\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "4",
-                      "label" : "\"Shelbyville\"" },
+                      "label" : 
+                      { "value" : "\"Shelbyville\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "5",
-                      "label" : "\"Dagstuhl\"" } ],
+                      "label" : 
+                      { "value" : "\"Dagstuhl\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "BIRTH_CHARACTER3" },
                   "bindingDependencies" : 
@@ -895,26 +1167,38 @@
               
               [ 
                 { "value" : "4",
-                  "label" : "\"Nelson Muntz\"" },
+                  "label" : 
+                  { "value" : "\"Nelson Muntz\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "j6yzoc6g-QOP-kewvj21j",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Albuquerque\"" },
+                      "label" : 
+                      { "value" : "\"Albuquerque\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Springfield\"" },
+                      "label" : 
+                      { "value" : "\"Springfield\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Portland\"" },
+                      "label" : 
+                      { "value" : "\"Portland\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "4",
-                      "label" : "\"Shelbyville\"" },
+                      "label" : 
+                      { "value" : "\"Shelbyville\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "5",
-                      "label" : "\"Dagstuhl\"" } ],
+                      "label" : 
+                      { "value" : "\"Dagstuhl\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "BIRTH_CHARACTER4" },
                   "bindingDependencies" : 
@@ -922,26 +1206,38 @@
               
               [ 
                 { "value" : "5",
-                  "label" : "\"Crazy Cat Lady\"" },
+                  "label" : 
+                  { "value" : "\"Crazy Cat Lady\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "j6yzoc6g-QOP-kewva5uf",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Albuquerque\"" },
+                      "label" : 
+                      { "value" : "\"Albuquerque\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Springfield\"" },
+                      "label" : 
+                      { "value" : "\"Springfield\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Portland\"" },
+                      "label" : 
+                      { "value" : "\"Portland\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "4",
-                      "label" : "\"Shelbyville\"" },
+                      "label" : 
+                      { "value" : "\"Shelbyville\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "5",
-                      "label" : "\"Dagstuhl\"" } ],
+                      "label" : 
+                      { "value" : "\"Dagstuhl\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "BIRTH_CHARACTER5" },
                   "bindingDependencies" : 
@@ -950,7 +1246,9 @@
       { "id" : "j4nw88h2",
         "componentType" : "Sequence",
         "page" : "23",
-        "label" : "\"IV - General questions\"",
+        "label" : 
+        { "value" : "\"IV - General questions\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -959,13 +1257,17 @@
         { "sequence" : 
           { "id" : "j4nw88h2",
             "page" : "23",
-            "label" : "\"IV - General questions\"" } },
+            "label" : 
+            { "value" : "\"IV - General questions\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j6qe237q",
             "componentType" : "Subsequence",
             "goToPage" : "24",
-            "label" : "\"Kwik-E-Mart\"",
+            "label" : 
+            { "value" : "\"Kwik-E-Mart\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -974,11 +1276,15 @@
             { "sequence" : 
               { "id" : "j4nw88h2",
                 "page" : "23",
-                "label" : "\"IV - General questions\"" },
+                "label" : 
+                { "value" : "\"IV - General questions\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "j6qe237q",
                 "page" : "24",
-                "label" : "\"Kwik-E-Mart\"" } },
+                "label" : 
+                { "value" : "\"Kwik-E-Mart\"",
+                  "type" : "VTL|MD" } } },
             "components" : 
             [ 
               { "id" : "j4nwc63q",
@@ -986,7 +1292,9 @@
                 "mandatory" : false,
                 "page" : "24",
                 "positioning" : "HORIZONTAL",
-                "label" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+                "label" : 
+                { "value" : "\"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -995,11 +1303,15 @@
                 { "sequence" : 
                   { "id" : "j4nw88h2",
                     "page" : "23",
-                    "label" : "\"IV - General questions\"" },
+                    "label" : 
+                    { "value" : "\"IV - General questions\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6qe237q",
                     "page" : "24",
-                    "label" : "\"Kwik-E-Mart\"" } },
+                    "label" : 
+                    { "value" : "\"Kwik-E-Mart\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "PERCENTAGE_EXPENSES11",
                   "PERCENTAGE_EXPENSES21",
@@ -1013,18 +1325,26 @@
                   [ 
                     { "headerCell" : true,
                       "colspan" : 2,
-                      "label" : "" },
+                      "label" : 
+                      { "value" : "",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Percentage\"" } ],
+                      "label" : 
+                      { "value" : "\"Percentage\"",
+                        "type" : "VTL|MD" } } ],
                   
                   [ 
                     { "rowspan" : 2,
                       "value" : "A",
-                      "label" : "\"Frozen products\"" },
+                      "label" : 
+                      { "value" : "\"Frozen products\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "A1",
-                      "label" : "\"Ice creams\"" },
+                      "label" : 
+                      { "value" : "\"Ice creams\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1039,7 +1359,9 @@
                   
                   [ 
                     { "value" : "A2",
-                      "label" : "\"Jasper Beardly\"" },
+                      "label" : 
+                      { "value" : "\"Jasper Beardly\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1055,10 +1377,14 @@
                   [ 
                     { "rowspan" : 3,
                       "value" : "B",
-                      "label" : "\"Meat\"" },
+                      "label" : 
+                      { "value" : "\"Meat\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "B1",
-                      "label" : "\"Bacon\"" },
+                      "label" : 
+                      { "value" : "\"Bacon\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1073,7 +1399,9 @@
                   
                   [ 
                     { "value" : "B2",
-                      "label" : "\"Pork chop\"" },
+                      "label" : 
+                      { "value" : "\"Pork chop\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1088,7 +1416,9 @@
                   
                   [ 
                     { "value" : "B3",
-                      "label" : "\"Chicken\"" },
+                      "label" : 
+                      { "value" : "\"Chicken\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1103,10 +1433,14 @@
                   
                   [ 
                     { "value" : "C",
-                      "label" : "\"Compote\"" },
+                      "label" : 
+                      { "value" : "\"Compote\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "C1",
-                      "label" : "\"Powersauce\"" },
+                      "label" : 
+                      { "value" : "\"Powersauce\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1122,7 +1456,9 @@
                   [ 
                     { "colspan" : 2,
                       "value" : "D",
-                      "label" : "\"Other\"" },
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "InputNumber",
                       "min" : 0,
@@ -1138,7 +1474,9 @@
                   [ 
                     { "colspan" : 2,
                       "value" : "E",
-                      "label" : "\"Total\"" },
+                      "label" : 
+                      { "value" : "\"Total\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : false } ] ] },
               
@@ -1147,7 +1485,9 @@
                 "mandatory" : false,
                 "page" : "25",
                 "positioning" : "HORIZONTAL",
-                "label" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+                "label" : 
+                { "value" : "\"➡ 2. Please specify if Jay has bought each product in his last food shopping\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -1156,11 +1496,15 @@
                 { "sequence" : 
                   { "id" : "j4nw88h2",
                     "page" : "23",
-                    "label" : "\"IV - General questions\"" },
+                    "label" : 
+                    { "value" : "\"IV - General questions\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6qe237q",
                     "page" : "24",
-                    "label" : "\"Kwik-E-Mart\"" } },
+                    "label" : 
+                    { "value" : "\"Kwik-E-Mart\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "LAST_FOOD_SHOPPING11",
                   "LAST_FOOD_SHOPPING21",
@@ -1175,31 +1519,45 @@
                   [ 
                     { "headerCell" : true,
                       "colspan" : 2,
-                      "label" : "" },
+                      "label" : 
+                      { "value" : "",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"In his last food shopping\"" } ],
+                      "label" : 
+                      { "value" : "\"In his last food shopping\"",
+                        "type" : "VTL|MD" } } ],
                   
                   [ 
                     { "rowspan" : 2,
                       "value" : "A",
-                      "label" : "\"Frozen products\"" },
+                      "label" : 
+                      { "value" : "\"Frozen products\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "A1",
-                      "label" : "\"Ice creams\"" },
+                      "label" : 
+                      { "value" : "\"Ice creams\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6pljq",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING11" },
                       "bindingDependencies" : 
@@ -1207,20 +1565,28 @@
                   
                   [ 
                     { "value" : "A2",
-                      "label" : "\"Jasper Beardly\"" },
+                      "label" : 
+                      { "value" : "\"Jasper Beardly\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6mgpv",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING21" },
                       "bindingDependencies" : 
@@ -1229,23 +1595,33 @@
                   [ 
                     { "rowspan" : 3,
                       "value" : "B",
-                      "label" : "\"Meat\"" },
+                      "label" : 
+                      { "value" : "\"Meat\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "B1",
-                      "label" : "\"Bacon\"" },
+                      "label" : 
+                      { "value" : "\"Bacon\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6pmtz",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING31" },
                       "bindingDependencies" : 
@@ -1253,20 +1629,28 @@
                   
                   [ 
                     { "value" : "B2",
-                      "label" : "\"Pork chop\"" },
+                      "label" : 
+                      { "value" : "\"Pork chop\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6k4lf",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING41" },
                       "bindingDependencies" : 
@@ -1274,20 +1658,28 @@
                   
                   [ 
                     { "value" : "B3",
-                      "label" : "\"Chicken\"" },
+                      "label" : 
+                      { "value" : "\"Chicken\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6p70n",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING51" },
                       "bindingDependencies" : 
@@ -1295,23 +1687,33 @@
                   
                   [ 
                     { "value" : "C",
-                      "label" : "\"Compote\"" },
+                      "label" : 
+                      { "value" : "\"Compote\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "C1",
-                      "label" : "\"Powersauce\"" },
+                      "label" : 
+                      { "value" : "\"Powersauce\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6lh5v",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING61" },
                       "bindingDependencies" : 
@@ -1320,20 +1722,28 @@
                   [ 
                     { "colspan" : 2,
                       "value" : "D",
-                      "label" : "\"Other\"" },
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq703te",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING71" },
                       "bindingDependencies" : 
@@ -1342,20 +1752,28 @@
                   [ 
                     { "colspan" : 2,
                       "value" : "E",
-                      "label" : "\"Total\"" },
+                      "label" : 
+                      { "value" : "\"Total\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxOne",
                       "id" : "k9cg2q5t-QOP-kiq6zpd3",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Yes\"" },
+                          "label" : 
+                          { "value" : "\"Yes\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"No\"" },
+                          "label" : 
+                          { "value" : "\"No\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "LAST_FOOD_SHOPPING81" },
                       "bindingDependencies" : 
@@ -1364,7 +1782,9 @@
           { "id" : "j6qejudb",
             "componentType" : "Subsequence",
             "goToPage" : "26",
-            "label" : "\"Clowning\"",
+            "label" : 
+            { "value" : "\"Clowning\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -1373,11 +1793,15 @@
             { "sequence" : 
               { "id" : "j4nw88h2",
                 "page" : "23",
-                "label" : "\"IV - General questions\"" },
+                "label" : 
+                { "value" : "\"IV - General questions\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "j6qejudb",
                 "page" : "26",
-                "label" : "\"Clowning\"" } },
+                "label" : 
+                { "value" : "\"Clowning\"",
+                  "type" : "VTL|MD" } } },
             "components" : 
             [ 
               { "id" : "kbkjvgel",
@@ -1385,7 +1809,9 @@
                 "mandatory" : false,
                 "page" : "26",
                 "positioning" : "HORIZONTAL",
-                "label" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+                "label" : 
+                { "value" : "\"➡ 3. Who did these clownings and tell us what you remember?\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -1394,11 +1820,15 @@
                 { "sequence" : 
                   { "id" : "j4nw88h2",
                     "page" : "23",
-                    "label" : "\"IV - General questions\"" },
+                    "label" : 
+                    { "value" : "\"IV - General questions\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6qejudb",
                     "page" : "26",
-                    "label" : "\"Clowning\"" } },
+                    "label" : 
+                    { "value" : "\"Clowning\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "CLOWNING11",
                   "CLOWNING12",
@@ -1412,33 +1842,49 @@
                 [ 
                   [ 
                     { "headerCell" : true,
-                      "label" : "" },
+                      "label" : 
+                      { "value" : "",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Clowning\"" },
+                      "label" : 
+                      { "value" : "\"Clowning\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Remember?\"" } ],
+                      "label" : 
+                      { "value" : "\"Remember?\"",
+                        "type" : "VTL|MD" } } ],
                   
                   [ 
                     { "value" : "1",
-                      "label" : "\"Break the windows of the whole city\"" },
+                      "label" : 
+                      { "value" : "\"Break the windows of the whole city\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "Dropdown",
                       "id" : "kbkjvgel-QOP-kiq6m5n0",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Jay\"" },
+                          "label" : 
+                          { "value" : "\"Jay\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"Bart\"" },
+                          "label" : 
+                          { "value" : "\"Bart\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Krusty the clown\"" },
+                          "label" : 
+                          { "value" : "\"Krusty the clown\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "O",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "CLOWNING11" },
                       "bindingDependencies" : 
@@ -1454,23 +1900,33 @@
                   
                   [ 
                     { "value" : "2",
-                      "label" : "\"Loose the violin of his daughter playing poker\"" },
+                      "label" : 
+                      { "value" : "\"Loose the violin of his daughter playing poker\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "Dropdown",
                       "id" : "kbkjvgel-QOP-kiq6l29o",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Jay\"" },
+                          "label" : 
+                          { "value" : "\"Jay\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"Bart\"" },
+                          "label" : 
+                          { "value" : "\"Bart\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Krusty the clown\"" },
+                          "label" : 
+                          { "value" : "\"Krusty the clown\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "O",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "CLOWNING21" },
                       "bindingDependencies" : 
@@ -1486,23 +1942,33 @@
                   
                   [ 
                     { "value" : "3",
-                      "label" : "\"Kill Mr Burns\"" },
+                      "label" : 
+                      { "value" : "\"Kill Mr Burns\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "Dropdown",
                       "id" : "kbkjvgel-QOP-kiq72biw",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Jay\"" },
+                          "label" : 
+                          { "value" : "\"Jay\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"Bart\"" },
+                          "label" : 
+                          { "value" : "\"Bart\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Krusty the clown\"" },
+                          "label" : 
+                          { "value" : "\"Krusty the clown\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "O",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "CLOWNING31" },
                       "bindingDependencies" : 
@@ -1518,23 +1984,33 @@
                   
                   [ 
                     { "value" : "4",
-                      "label" : "\"Leaving a mechanical object to control the nuclear power plant\"" },
+                      "label" : 
+                      { "value" : "\"Leaving a mechanical object to control the nuclear power plant\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "Dropdown",
                       "id" : "kbkjvgel-QOP-kiq6mlan",
                       "options" : 
                       [ 
                         { "value" : "1",
-                          "label" : "\"Jay\"" },
+                          "label" : 
+                          { "value" : "\"Jay\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "2",
-                          "label" : "\"Bart\"" },
+                          "label" : 
+                          { "value" : "\"Bart\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "3",
-                          "label" : "\"Krusty the clown\"" },
+                          "label" : 
+                          { "value" : "\"Krusty the clown\"",
+                            "type" : "VTL|MD" } },
                         
                         { "value" : "O",
-                          "label" : "\"Other\"" } ],
+                          "label" : 
+                          { "value" : "\"Other\"",
+                            "type" : "VTL|MD" } } ],
                       "response" : 
                       { "name" : "CLOWNING41" },
                       "bindingDependencies" : 
@@ -1551,7 +2027,9 @@
           { "id" : "j6qeh91y",
             "componentType" : "Subsequence",
             "goToPage" : "27",
-            "label" : "\"Transport\"",
+            "label" : 
+            { "value" : "\"Transport\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -1560,11 +2038,15 @@
             { "sequence" : 
               { "id" : "j4nw88h2",
                 "page" : "23",
-                "label" : "\"IV - General questions\"" },
+                "label" : 
+                { "value" : "\"IV - General questions\"",
+                  "type" : "VTL|MD" } },
               "subSequence" : 
               { "id" : "j6qeh91y",
                 "page" : "27",
-                "label" : "\"Transport\"" } },
+                "label" : 
+                { "value" : "\"Transport\"",
+                  "type" : "VTL|MD" } } },
             "components" : 
             [ 
               { "id" : "j6p2lwuj",
@@ -1572,13 +2054,17 @@
                 "mandatory" : false,
                 "page" : "27",
                 "positioning" : "HORIZONTAL",
-                "label" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+                "label" : 
+                { "value" : "\"➡ 4. Which of the following means of transport were used by the hero and in which country?\"",
+                  "type" : "VTL|MD" },
                 "declarations" : 
                 [ 
                   { "id" : "j6p2lwuj-d10",
                     "declarationType" : "INSTRUCTION",
                     "position" : "AFTER_QUESTION_TEXT",
-                    "label" : "\"Several answers possible: check off all the relevant boxes\"" } ],
+                    "label" : 
+                    { "value" : "\"Several answers possible: check off all the relevant boxes\"",
+                      "type" : "VTL|MD" } } ],
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -1587,11 +2073,15 @@
                 { "sequence" : 
                   { "id" : "j4nw88h2",
                     "page" : "23",
-                    "label" : "\"IV - General questions\"" },
+                    "label" : 
+                    { "value" : "\"IV - General questions\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "j6qeh91y",
                     "page" : "27",
-                    "label" : "\"Transport\"" } },
+                    "label" : 
+                    { "value" : "\"Transport\"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "TRAVEL11",
                   "TRAVEL12",
@@ -1621,29 +2111,45 @@
                 [ 
                   [ 
                     { "headerCell" : true,
-                      "label" : "" },
+                      "label" : 
+                      { "value" : "",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Brazil\"" },
+                      "label" : 
+                      { "value" : "\"Brazil\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Canada\"" },
+                      "label" : 
+                      { "value" : "\"Canada\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Japan\"" },
+                      "label" : 
+                      { "value" : "\"Japan\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"France\"" },
+                      "label" : 
+                      { "value" : "\"France\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Other country\"" },
+                      "label" : 
+                      { "value" : "\"Other country\"",
+                        "type" : "VTL|MD" } },
                     
                     { "headerCell" : true,
-                      "label" : "\"Other planet\"" } ],
+                      "label" : 
+                      { "value" : "\"Other planet\"",
+                        "type" : "VTL|MD" } } ],
                   
                   [ 
                     { "value" : "1",
-                      "label" : "\"Car\"" },
+                      "label" : 
+                      { "value" : "\"Car\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxBoolean",
                       "id" : "j6p2lwuj-QOP-kewvm4qg",
@@ -1689,7 +2195,9 @@
                   
                   [ 
                     { "value" : "2",
-                      "label" : "\"Bike\"" },
+                      "label" : 
+                      { "value" : "\"Bike\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxBoolean",
                       "id" : "j6p2lwuj-QOP-kewvebem",
@@ -1735,7 +2243,9 @@
                   
                   [ 
                     { "value" : "3",
-                      "label" : "\"Skateboard\"" },
+                      "label" : 
+                      { "value" : "\"Skateboard\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxBoolean",
                       "id" : "j6p2lwuj-QOP-kewv62xx",
@@ -1781,7 +2291,9 @@
                   
                   [ 
                     { "value" : "4",
-                      "label" : "\"Plane\"" },
+                      "label" : 
+                      { "value" : "\"Plane\"",
+                        "type" : "VTL|MD" } },
                     
                     { "componentType" : "CheckboxBoolean",
                       "id" : "j6p2lwuj-QOP-kewvjcck",
@@ -1828,7 +2340,9 @@
       { "id" : "j6qfx9qe",
         "componentType" : "Sequence",
         "page" : "28",
-        "label" : "\"V - Favourite characters (dynamic table)\"",
+        "label" : 
+        { "value" : "\"V - Favourite characters (dynamic table)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -1837,7 +2351,9 @@
         { "sequence" : 
           { "id" : "j6qfx9qe",
             "page" : "28",
-            "label" : "\"V - Favourite characters (dynamic table)\"" } },
+            "label" : 
+            { "value" : "\"V - Favourite characters (dynamic table)\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j6qg8rc6",
@@ -1845,7 +2361,9 @@
             "mandatory" : false,
             "page" : "29",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+            "label" : 
+            { "value" : "\"➡ 1. Please, complete the following grid with your favourite characters\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -1854,7 +2372,9 @@
             { "sequence" : 
               { "id" : "j6qfx9qe",
                 "page" : "28",
-                "label" : "\"V - Favourite characters (dynamic table)\"" } },
+                "label" : 
+                { "value" : "\"V - Favourite characters (dynamic table)\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "FAVOURITE_CHAR1",
               "FAVOURITE_CHAR2",
@@ -1896,13 +2416,19 @@
             [ 
               [ 
                 { "headerCell" : true,
-                  "label" : "\"Name\"" },
+                  "label" : 
+                  { "value" : "\"Name\"",
+                    "type" : "VTL|MD" } },
                 
                 { "headerCell" : true,
-                  "label" : "\"Age\"" },
+                  "label" : 
+                  { "value" : "\"Age\"",
+                    "type" : "VTL|MD" } },
                 
                 { "headerCell" : true,
-                  "label" : "\"Member of the Simpsons family\"" } ],
+                  "label" : 
+                  { "value" : "\"Member of the Simpsons family\"",
+                    "type" : "VTL|MD" } } ],
               
               [ 
                 { "componentType" : "Textarea",
@@ -1926,13 +2452,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_1_3" },
                   "bindingDependencies" : 
@@ -1960,13 +2492,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_2_3" },
                   "bindingDependencies" : 
@@ -1994,13 +2532,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_3_3" },
                   "bindingDependencies" : 
@@ -2028,13 +2572,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_4_3" },
                   "bindingDependencies" : 
@@ -2062,13 +2612,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_5_3" },
                   "bindingDependencies" : 
@@ -2096,13 +2652,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_6_3" },
                   "bindingDependencies" : 
@@ -2130,13 +2692,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_7_3" },
                   "bindingDependencies" : 
@@ -2164,13 +2732,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_8_3" },
                   "bindingDependencies" : 
@@ -2198,13 +2772,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_9_3" },
                   "bindingDependencies" : 
@@ -2232,13 +2812,19 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Yes\"" },
+                      "label" : 
+                      { "value" : "\"Yes\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"No\"" },
+                      "label" : 
+                      { "value" : "\"No\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Other\"" } ],
+                      "label" : 
+                      { "value" : "\"Other\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FAVOURITE_CHAR3_10_3" },
                   "bindingDependencies" : 
@@ -2249,7 +2835,9 @@
             "mandatory" : false,
             "page" : "30",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+            "label" : 
+            { "value" : "\"➡ 2. How has your feeling about the following characters evolved over time?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2258,7 +2846,9 @@
             { "sequence" : 
               { "id" : "j6qfx9qe",
                 "page" : "28",
-                "label" : "\"V - Favourite characters (dynamic table)\"" } },
+                "label" : 
+                { "value" : "\"V - Favourite characters (dynamic table)\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "FEELCHAREV1",
               "FEELCHAREV2",
@@ -2268,20 +2858,28 @@
             [ 
               [ 
                 { "value" : "1",
-                  "label" : "\"Jay\"" },
+                  "label" : 
+                  { "value" : "\"Jay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "jvxux0mi-QOP-kiq76emy",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Up\"" },
+                      "label" : 
+                      { "value" : "\"Up\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Down\"" },
+                      "label" : 
+                      { "value" : "\"Down\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Steady\"" } ],
+                      "label" : 
+                      { "value" : "\"Steady\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FEELCHAREV1" },
                   "bindingDependencies" : 
@@ -2289,20 +2887,28 @@
               
               [ 
                 { "value" : "2",
-                  "label" : "\"Bart\"" },
+                  "label" : 
+                  { "value" : "\"Bart\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "jvxux0mi-QOP-kiq6zv60",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Up\"" },
+                      "label" : 
+                      { "value" : "\"Up\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Down\"" },
+                      "label" : 
+                      { "value" : "\"Down\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Steady\"" } ],
+                      "label" : 
+                      { "value" : "\"Steady\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FEELCHAREV2" },
                   "bindingDependencies" : 
@@ -2310,20 +2916,28 @@
               
               [ 
                 { "value" : "3",
-                  "label" : "\"Krusty the clown\"" },
+                  "label" : 
+                  { "value" : "\"Krusty the clown\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "jvxux0mi-QOP-kiq7bgk3",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Up\"" },
+                      "label" : 
+                      { "value" : "\"Up\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Down\"" },
+                      "label" : 
+                      { "value" : "\"Down\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Steady\"" } ],
+                      "label" : 
+                      { "value" : "\"Steady\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FEELCHAREV3" },
                   "bindingDependencies" : 
@@ -2331,20 +2945,28 @@
               
               [ 
                 { "value" : "O",
-                  "label" : "\"Other\"" },
+                  "label" : 
+                  { "value" : "\"Other\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "CheckboxOne",
                   "id" : "jvxux0mi-QOP-kiq6ync3",
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Up\"" },
+                      "label" : 
+                      { "value" : "\"Up\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Down\"" },
+                      "label" : 
+                      { "value" : "\"Down\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "3",
-                      "label" : "\"Steady\"" } ],
+                      "label" : 
+                      { "value" : "\"Steady\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "FEELCHAREV4" },
                   "bindingDependencies" : 
@@ -2355,7 +2977,9 @@
             "mandatory" : false,
             "page" : "31",
             "positioning" : "HORIZONTAL",
-            "label" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+            "label" : 
+            { "value" : "\"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2364,7 +2988,9 @@
             { "sequence" : 
               { "id" : "j6qfx9qe",
                 "page" : "28",
-                "label" : "\"V - Favourite characters (dynamic table)\"" } },
+                "label" : 
+                { "value" : "\"V - Favourite characters (dynamic table)\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "LEAVDURATION11",
               "LEAVDURATION12",
@@ -2380,17 +3006,25 @@
             [ 
               [ 
                 { "headerCell" : true,
-                  "label" : "" },
+                  "label" : 
+                  { "value" : "",
+                    "type" : "VTL|MD" } },
                 
                 { "headerCell" : true,
-                  "label" : "\"Days\"" },
+                  "label" : 
+                  { "value" : "\"Days\"",
+                    "type" : "VTL|MD" } },
                 
                 { "headerCell" : true,
-                  "label" : "\"Unit\"" } ],
+                  "label" : 
+                  { "value" : "\"Unit\"",
+                    "type" : "VTL|MD" } } ],
               
               [ 
                 { "value" : "1",
-                  "label" : "\"Leave with pay\"" },
+                  "label" : 
+                  { "value" : "\"Leave with pay\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "InputNumber",
                   "min" : 0,
@@ -2407,10 +3041,14 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Working Days\"" },
+                      "label" : 
+                      { "value" : "\"Working Days\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Calendar days\"" } ],
+                      "label" : 
+                      { "value" : "\"Calendar days\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "LEAVDURATION12" },
                   "bindingDependencies" : 
@@ -2418,7 +3056,9 @@
               
               [ 
                 { "value" : "2",
-                  "label" : "\"Public holiday\"" },
+                  "label" : 
+                  { "value" : "\"Public holiday\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "InputNumber",
                   "min" : 0,
@@ -2435,10 +3075,14 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Working Days\"" },
+                      "label" : 
+                      { "value" : "\"Working Days\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Calendar days\"" } ],
+                      "label" : 
+                      { "value" : "\"Calendar days\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "LEAVDURATION22" },
                   "bindingDependencies" : 
@@ -2446,7 +3090,9 @@
               
               [ 
                 { "value" : "3",
-                  "label" : "\"Sick leave\"" },
+                  "label" : 
+                  { "value" : "\"Sick leave\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "InputNumber",
                   "min" : 0,
@@ -2463,10 +3109,14 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Working Days\"" },
+                      "label" : 
+                      { "value" : "\"Working Days\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Calendar days\"" } ],
+                      "label" : 
+                      { "value" : "\"Calendar days\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "LEAVDURATION32" },
                   "bindingDependencies" : 
@@ -2474,7 +3124,9 @@
               
               [ 
                 { "value" : "4",
-                  "label" : "\"Maternity\/paternity leave\"" },
+                  "label" : 
+                  { "value" : "\"Maternity\/paternity leave\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "InputNumber",
                   "min" : 0,
@@ -2491,10 +3143,14 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Working Days\"" },
+                      "label" : 
+                      { "value" : "\"Working Days\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Calendar days\"" } ],
+                      "label" : 
+                      { "value" : "\"Calendar days\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "LEAVDURATION42" },
                   "bindingDependencies" : 
@@ -2502,7 +3158,9 @@
               
               [ 
                 { "value" : "5",
-                  "label" : "\"Other type\"" },
+                  "label" : 
+                  { "value" : "\"Other type\"",
+                    "type" : "VTL|MD" } },
                 
                 { "componentType" : "InputNumber",
                   "min" : 0,
@@ -2519,10 +3177,14 @@
                   "options" : 
                   [ 
                     { "value" : "1",
-                      "label" : "\"Working Days\"" },
+                      "label" : 
+                      { "value" : "\"Working Days\"",
+                        "type" : "VTL|MD" } },
                     
                     { "value" : "2",
-                      "label" : "\"Calendar days\"" } ],
+                      "label" : 
+                      { "value" : "\"Calendar days\"",
+                        "type" : "VTL|MD" } } ],
                   "response" : 
                   { "name" : "LEAVDURATION52" },
                   "bindingDependencies" : 
@@ -2531,7 +3193,9 @@
       { "id" : "kiq5mr0b",
         "componentType" : "Sequence",
         "page" : "32",
-        "label" : "\"VI - Favourite characters (Loop)\"",
+        "label" : 
+        { "value" : "\"VI - Favourite characters (Loop)\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "(not(cast(READY,integer)  <>  1))",
           "bindingDependencies" : 
@@ -2540,7 +3204,9 @@
         { "sequence" : 
           { "id" : "kiq5mr0b",
             "page" : "32",
-            "label" : "\"VI - Favourite characters (Loop)\"" } },
+            "label" : 
+            { "value" : "\"VI - Favourite characters (Loop)\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "kiq612ky",
@@ -2550,7 +3216,9 @@
             "min" : 0,
             "max" : 20,
             "decimals" : 0,
-            "label" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+            "label" : 
+            { "value" : "\"➡ 1. How many characters from the Simpsons family could you precisely describe?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2559,7 +3227,9 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" } },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NB_CHAR" ],
             "response" : 
@@ -2569,7 +3239,9 @@
             "componentType" : "Loop",
             "page" : "34",
             "paginatedLoop" : false,
-            "label" : "\"Add a character\"",
+            "label" : 
+            { "value" : "\"Add a character\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2578,7 +3250,9 @@
             { "sequence" : 
               { "id" : "kiq5mr0b",
                 "page" : "32",
-                "label" : "\"VI - Favourite characters (Loop)\"" } },
+                "label" : 
+                { "value" : "\"VI - Favourite characters (Loop)\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR",
               "AGE_CHAR" ],
@@ -2588,7 +3262,9 @@
                 "componentType" : "Subsequence",
                 "page" : "34",
                 "goToPage" : "34",
-                "label" : "\"Description of each character\"",
+                "label" : 
+                { "value" : "\"Description of each character\"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -2597,11 +3273,15 @@
                 { "sequence" : 
                   { "id" : "kiq5mr0b",
                     "page" : "32",
-                    "label" : "\"VI - Favourite characters (Loop)\"" },
+                    "label" : 
+                    { "value" : "\"VI - Favourite characters (Loop)\"",
+                      "type" : "VTL|MD" } },
                   "subSequence" : 
                   { "id" : "kiq5u8d5",
                     "page" : "34",
-                    "label" : "\"Description of each character\"" } },
+                    "label" : 
+                    { "value" : "\"Description of each character\"",
+                      "type" : "VTL|MD" } } },
                 "components" : 
                 [ 
                   { "id" : "kiq66gtw",
@@ -2609,7 +3289,9 @@
                     "mandatory" : false,
                     "page" : "34",
                     "maxLength" : 30,
-                    "label" : "\"➡ 2. What is the first name of this character?\"",
+                    "label" : 
+                    { "value" : "\"➡ 2. What is the first name of this character?\"",
+                      "type" : "VTL|MD" },
                     "conditionFilter" : 
                     { "value" : "(not(cast(READY,integer)  <>  1))",
                       "bindingDependencies" : 
@@ -2618,11 +3300,15 @@
                     { "sequence" : 
                       { "id" : "kiq5mr0b",
                         "page" : "32",
-                        "label" : "\"VI - Favourite characters (Loop)\"" },
+                        "label" : 
+                        { "value" : "\"VI - Favourite characters (Loop)\"",
+                          "type" : "VTL|MD" } },
                       "subSequence" : 
                       { "id" : "kiq5u8d5",
                         "page" : "34",
-                        "label" : "\"Description of each character\"" } },
+                        "label" : 
+                        { "value" : "\"Description of each character\"",
+                          "type" : "VTL|MD" } } },
                     "bindingDependencies" : 
                     [ "NAME_CHAR" ],
                     "response" : 
@@ -2635,7 +3321,9 @@
                     "min" : 0,
                     "max" : 120,
                     "decimals" : 0,
-                    "label" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+                    "label" : 
+                    { "value" : "\"➡ 3. How old is this character in the first episode of the Simpsons family?\"",
+                      "type" : "VTL|MD" },
                     "conditionFilter" : 
                     { "value" : "(not(cast(READY,integer)  <>  1))",
                       "bindingDependencies" : 
@@ -2644,11 +3332,15 @@
                     { "sequence" : 
                       { "id" : "kiq5mr0b",
                         "page" : "32",
-                        "label" : "\"VI - Favourite characters (Loop)\"" },
+                        "label" : 
+                        { "value" : "\"VI - Favourite characters (Loop)\"",
+                          "type" : "VTL|MD" } },
                       "subSequence" : 
                       { "id" : "kiq5u8d5",
                         "page" : "34",
-                        "label" : "\"Description of each character\"" } },
+                        "label" : 
+                        { "value" : "\"Description of each character\"",
+                          "type" : "VTL|MD" } } },
                     "bindingDependencies" : 
                     [ "AGE_CHAR" ],
                     "response" : 
@@ -2677,7 +3369,9 @@
           { "id" : "kiq5xw5p",
             "componentType" : "Sequence",
             "page" : "35.1",
-            "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+            "label" : 
+            { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "(not(cast(READY,integer)  <>  1))",
               "bindingDependencies" : 
@@ -2686,7 +3380,9 @@
             { "sequence" : 
               { "id" : "kiq5xw5p",
                 "page" : "35.1",
-                "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                "label" : 
+                { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "NAME_CHAR" ],
             "components" : 
@@ -2695,7 +3391,9 @@
                 "componentType" : "CheckboxOne",
                 "mandatory" : false,
                 "page" : "35.2",
-                "label" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+                "label" : 
+                { "value" : "\"➡ 1. Is character named \" || cast(cast(NAME_CHAR,string),string) || \" your favourite one ? \"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -2704,17 +3402,23 @@
                 { "sequence" : 
                   { "id" : "kiq5xw5p",
                     "page" : "35.1",
-                    "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                    "label" : 
+                    { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "NAME_CHAR",
                   "FAVCHAR" ],
                 "options" : 
                 [ 
                   { "value" : "1",
-                    "label" : "\"Yes\"" },
+                    "label" : 
+                    { "value" : "\"Yes\"",
+                      "type" : "VTL|MD" } },
                   
                   { "value" : "0",
-                    "label" : "\"No\"" } ],
+                    "label" : 
+                    { "value" : "\"No\"",
+                      "type" : "VTL|MD" } } ],
                 "response" : 
                 { "name" : "FAVCHAR" } },
               
@@ -2723,7 +3427,9 @@
                 "mandatory" : false,
                 "page" : "35.3",
                 "maxLength" : 255,
-                "label" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+                "label" : 
+                { "value" : "\"➡ 2. What is your best memory about character named \" || cast(cast(NAME_CHAR,string),string) || \" ? \"",
+                  "type" : "VTL|MD" },
                 "conditionFilter" : 
                 { "value" : "(not(cast(READY,integer)  <>  1))",
                   "bindingDependencies" : 
@@ -2732,7 +3438,9 @@
                 { "sequence" : 
                   { "id" : "kiq5xw5p",
                     "page" : "35.1",
-                    "label" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"" } },
+                    "label" : 
+                    { "value" : "\"VII - Other details about character named \" || cast(cast(NAME_CHAR,string),string) || \" \"",
+                      "type" : "VTL|MD" } } },
                 "bindingDependencies" : 
                 [ "NAME_CHAR",
                   "MEMORY_CHAR" ],
@@ -2742,14 +3450,18 @@
       { "id" : "j6z12s2d",
         "componentType" : "Sequence",
         "page" : "36",
-        "label" : "\"VIII - Comment\"",
+        "label" : 
+        { "value" : "\"VIII - Comment\"",
+          "type" : "VTL|MD" },
         "conditionFilter" : 
         { "value" : "true" },
         "hierarchy" : 
         { "sequence" : 
           { "id" : "j6z12s2d",
             "page" : "36",
-            "label" : "\"VIII - Comment\"" } },
+            "label" : 
+            { "value" : "\"VIII - Comment\"",
+              "type" : "VTL|MD" } } },
         "components" : 
         [ 
           { "id" : "j6z0z3us",
@@ -2757,14 +3469,18 @@
             "mandatory" : false,
             "page" : "37",
             "maxLength" : 255,
-            "label" : "\"➡ 1. Do you have any comment about the survey?\"",
+            "label" : 
+            { "value" : "\"➡ 1. Do you have any comment about the survey?\"",
+              "type" : "VTL|MD" },
             "conditionFilter" : 
             { "value" : "true" },
             "hierarchy" : 
             { "sequence" : 
               { "id" : "j6z12s2d",
                 "page" : "36",
-                "label" : "\"VIII - Comment\"" } },
+                "label" : 
+                { "value" : "\"VIII - Comment\"",
+                  "type" : "VTL|MD" } } },
             "bindingDependencies" : 
             [ "SURVEY_COMMENT" ],
             "response" : 

--- a/src/test/resources/examples/xmlh-2-xmlf/out.xml
+++ b/src/test/resources/examples/xmlh-2-xmlf/out.xml
@@ -6,23 +6,35 @@
                enoCoreVersion="2.2.8"
                pagination="question"
                maxPage="37">
-   <label>Questionnaire SIMPSONS 20201215</label>
+   <label>
+      <value>Questionnaire SIMPSONS 20201215</value>
+      <type>VTL|MD</type>
+   </label>
    <components xsi:type="Sequence"
                componentType="Sequence"
                id="j6p0ti5h"
                page="1">
-      <label>"I - Introduction"</label>
+      <label>
+         <value>"I - Introduction"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j6p0ti5h-d1"
                     position="AFTER_QUESTION_TEXT">
-         <label>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</label>
+         <label>
+            <value>"We’re going to test your knowledge about the simpsons series.Welcome in the simpsons world!"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
-            <label>"I - Introduction"</label>
+            <label>
+               <value>"I - Introduction"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -32,13 +44,19 @@
                maxLength="500"
                mandatory="true"
                page="2">
-         <label>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</label>
+         <label>
+            <value>"➡ 1. Before starting, do you have any comments about the Simpsons family?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>COMMENT</bindingDependencies>
@@ -49,18 +67,27 @@
                id="j6p0np9q"
                mandatory="false"
                page="3">
-         <label>"➡ 2. If you agree to answer this questionnaire, please check the box"</label>
+         <label>
+            <value>"➡ 2. If you agree to answer this questionnaire, please check the box"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="COMMENT"
                     id="j6p0np9q-kir6xl1e"
                     position="AFTER_QUESTION_TEXT">
-            <label>"If not, this is unfortunately the end of this questionnaire."</label>
+            <label>
+               <value>"If not, this is unfortunately the end of this questionnaire."</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>READY</bindingDependencies>
@@ -71,13 +98,19 @@
                id="j6p6my1d"
                filterDescription="false"
                page="3">
-         <label>"If you are not ready, please go to the end of the questionnaire"</label>
+         <label>
+            <value>"If you are not ready, please go to the end of the questionnaire"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
       </components>
@@ -85,17 +118,26 @@
                componentType="Subsequence"
                id="j6p0s7o5"
                goToPage="4">
-      <label>"General knowledge of the series"</label>
+      <label>
+            <value>"General knowledge of the series"</value>
+            <type>VTL|MD</type>
+         </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
             <sequence id="j6p0ti5h" page="1">
-               <label>"I - Introduction"</label>
+               <label>
+                  <value>"I - Introduction"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6p0s7o5" page="4">
-               <label>"General knowledge of the series"</label>
+               <label>
+                  <value>"General knowledge of the series"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
    </components>
@@ -105,17 +147,26 @@
                maxLength="30"
                mandatory="false"
                page="4">
-            <label>"➡ 3. Who is the producer?"</label>
+            <label>
+               <value>"➡ 3. Who is the producer?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>PRODUCER</bindingDependencies>
@@ -129,17 +180,26 @@
                max="99"
                decimals="0"
                page="5">
-            <label>"➡ 4. What is the current season number?"</label>
+            <label>
+               <value>"➡ 4. What is the current season number?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>SEASON_NUMBER</bindingDependencies>
@@ -152,11 +212,17 @@
                min="1900-01-01"
                max="format-date(current-date(),'[Y0001]-[M01]-[D01]')"
                page="6">
-            <label>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</label>
+            <label>
+               <value>"➡ 5. When was the first episode of Simpsons? (format YYYY-MM-DD)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="INSTRUCTION"
                     id="kiq71eoi-kiq7dsy2"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM-DD format"</label>
+               <label>
+                  <value>"Please answer with YYYY-MM-DD format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -164,10 +230,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEFIRST</bindingDependencies>
@@ -180,11 +252,17 @@
                mandatory="false"
                min="1980-05"
                page="7">
-            <label>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</label>
+            <label>
+               <value>"➡ 6. When was the first episode of the Simpsons? (format YYYY-MM)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="COMMENT"
                     id="k5nvty2o-k5nvxld8"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY-MM format"</label>
+               <label>
+                  <value>"Please answer with YYYY-MM format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -192,10 +270,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEYYYYMM</bindingDependencies>
@@ -209,11 +293,17 @@
                min="1900"
                max="year-from-date(current-date())"
                page="8">
-            <label>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</label>
+            <label>
+               <value>"➡ 7. When was the first episode of the Simpsons? (format YYYY)"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="COMMENT"
                     id="k5nw1fir-k5nvmx3n"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Please answer with YYYY format"</label>
+               <label>
+                  <value>"Please answer with YYYY format"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -221,10 +311,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DATEYYYY</bindingDependencies>
@@ -239,17 +335,26 @@
                max="70.00"
                decimals="2"
                page="9">
-            <label>"➡ 8. How long does an episode last?"</label>
+            <label>
+               <value>"➡ 8. How long does an episode last?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONH</bindingDependencies>
@@ -264,17 +369,26 @@
                max="366.0"
                decimals="1"
                page="10">
-            <label>"➡ 9. How long does it take to write a new episode?"</label>
+            <label>
+               <value>"➡ 9. How long does it take to write a new episode?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIOND</bindingDependencies>
@@ -289,17 +403,26 @@
                max="12"
                decimals="0"
                page="11">
-            <label>"➡ 10. How long will it take you to watch all the existing episodes?"</label>
+            <label>
+               <value>"➡ 10. How long will it take you to watch all the existing episodes?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONM</bindingDependencies>
@@ -314,17 +437,26 @@
                max="100"
                decimals="0"
                page="12">
-            <label>"➡ 11. For how long have you known the Simpsons family?"</label>
+            <label>
+               <value>"➡ 11. For how long have you known the Simpsons family?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>DURATIONY</bindingDependencies>
@@ -339,17 +471,26 @@
                max="99.0"
                decimals="1"
                page="13">
-            <label>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</label>
+            <label>
+               <value>"➡ 15. In your opinion, how much is the part of audience share in US for the 2016 season?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j6p0ti5h" page="1">
-                  <label>"I - Introduction"</label>
+                  <label>
+                     <value>"I - Introduction"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6p0s7o5" page="4">
-                  <label>"General knowledge of the series"</label>
+                  <label>
+                     <value>"General knowledge of the series"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>AUDIENCE_SHARE</bindingDependencies>
@@ -360,11 +501,17 @@
                componentType="Sequence"
                id="j3341528"
                page="14">
-      <label>"II - Simpsons’ city"</label>
+      <label>
+         <value>"II - Simpsons’ city"</value>
+         <type>VTL|MD</type>
+      </label>
       <declarations declarationType="COMMENT"
                     id="j3341528-d2"
                     position="AFTER_QUESTION_TEXT">
-         <label>"This module asks about your general knowledge of the Simpsons city"</label>
+         <label>
+            <value>"This module asks about your general knowledge of the Simpsons city"</value>
+            <type>VTL|MD</type>
+         </label>
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -372,7 +519,10 @@
       </conditionFilter>
       <hierarchy>
          <sequence id="j3341528" page="14">
-            <label>"II - Simpsons’ city"</label>
+            <label>
+               <value>"II - Simpsons’ city"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -381,11 +531,17 @@
                id="j3343clt"
                mandatory="true"
                page="15">
-         <label>"➡ 1. In which city do the Simpsons reside?"</label>
+         <label>
+            <value>"➡ 1. In which city do the Simpsons reside?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                     id="j3343clt-d3"
                     position="AFTER_QUESTION_TEXT">
-            <label>"One possible answer"</label>
+            <label>
+               <value>"One possible answer"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -393,21 +549,33 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>CITY</bindingDependencies>
          <options>
             <value>00001</value>
-            <label>"Springfield"</label>
+            <label>
+               <value>"Springfield"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>00002</value>
-            <label>"Shelbyville"</label>
+            <label>
+               <value>"Shelbyville"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>03</value>
-            <label>"Seinfeld"</label>
+            <label>
+               <value>"Seinfeld"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="CITY"/>
       </components>
@@ -416,11 +584,17 @@
                id="j6qdfhvw"
                mandatory="false"
                page="16">
-         <label>"➡ 2. Who is the Simpsons city mayor?"</label>
+         <label>
+            <value>"➡ 2. Who is the Simpsons city mayor?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                     id="j6qdfhvw-d4"
                     position="AFTER_QUESTION_TEXT">
-            <label>"Only one possible answer"</label>
+            <label>
+               <value>"Only one possible answer"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -428,25 +602,40 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>MAYOR</bindingDependencies>
          <options>
             <value>1</value>
-            <label>"Constance Harm"</label>
+            <label>
+               <value>"Constance Harm"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>2</value>
-            <label>"Timothy Lovejoy"</label>
+            <label>
+               <value>"Timothy Lovejoy"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>3</value>
-            <label>"Joe Quimby"</label>
+            <label>
+               <value>"Joe Quimby"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>OT</value>
-            <label>"Other name"</label>
+            <label>
+               <value>"Other name"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="MAYOR"/>
       </components>
@@ -455,68 +644,113 @@
                id="j4nw5cqz"
                mandatory="false"
                page="17">
-         <label>"➡ 3. In which state do The Simpsons reside?"</label>
+         <label>
+            <value>"➡ 3. In which state do The Simpsons reside?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j3341528" page="14">
-               <label>"II - Simpsons’ city"</label>
+               <label>
+                  <value>"II - Simpsons’ city"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>STATE</bindingDependencies>
          <options>
             <value>1</value>
-            <label>"Washington"</label>
+            <label>
+               <value>"Washington"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>2</value>
-            <label>"Kentucky"</label>
+            <label>
+               <value>"Kentucky"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>3</value>
-            <label>"Ohio"</label>
+            <label>
+               <value>"Ohio"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>4</value>
-            <label>"Maine"</label>
+            <label>
+               <value>"Maine"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>5</value>
-            <label>"North Dakota"</label>
+            <label>
+               <value>"North Dakota"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>6</value>
-            <label>"Florida"</label>
+            <label>
+               <value>"Florida"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>7</value>
-            <label>"North Takoma"</label>
+            <label>
+               <value>"North Takoma"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>8</value>
-            <label>"California"</label>
+            <label>
+               <value>"California"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>9</value>
-            <label>"Texas"</label>
+            <label>
+               <value>"Texas"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>10</value>
-            <label>"Massachusetts"</label>
+            <label>
+               <value>"Massachusetts"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>11</value>
-            <label>"Nevada"</label>
+            <label>
+               <value>"Nevada"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>12</value>
-            <label>"Illinois"</label>
+            <label>
+               <value>"Illinois"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <options>
             <value>13</value>
-            <label>"Not in any state, you fool!"</label>
+            <label>
+               <value>"Not in any state, you fool!"</value>
+               <type>VTL|MD</type>
+            </label>
          </options>
          <response name="STATE"/>
       </components>
@@ -524,14 +758,20 @@
                componentType="Sequence"
                id="j6qe0h9q"
                page="18">
-      <label>"III - Characters"</label>
+      <label>
+         <value>"III - Characters"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qe0h9q" page="18">
-            <label>"III - Characters"</label>
+            <label>
+               <value>"III - Characters"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -539,11 +779,17 @@
                componentType="CheckboxGroup"
                id="j334akov"
                page="19">
-         <label>"➡ 1. What are the pet names that the Simpsons family had?"</label>
+         <label>
+            <value>"➡ 1. What are the pet names that the Simpsons family had?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="INSTRUCTION"
                     id="j334akov-d5"
                     position="AFTER_QUESTION_TEXT">
-            <label>"Several possible answers"</label>
+            <label>
+               <value>"Several possible answers"</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -551,7 +797,10 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>PET1</bindingDependencies>
@@ -559,19 +808,31 @@
          <bindingDependencies>PET3</bindingDependencies>
          <bindingDependencies>PET4</bindingDependencies>
          <responses id="j334akov-QOP-khokqjtw">
-            <label>"Santa’s Little Helper"</label>
+            <label>
+               <value>"Santa’s Little Helper"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET1"/>
          </responses>
          <responses id="j334akov-QOP-khokur7a">
-            <label>"Snowball I"</label>
+            <label>
+               <value>"Snowball I"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET2"/>
          </responses>
          <responses id="j334akov-QOP-khol82ux">
-            <label>"Coltrane"</label>
+            <label>
+               <value>"Coltrane"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET3"/>
          </responses>
          <responses id="j334akov-QOP-khokqee5">
-            <label>"Other name"</label>
+            <label>
+               <value>"Other name"</value>
+               <type>VTL|MD</type>
+            </label>
             <response name="PET4"/>
          </responses>
       </components>
@@ -581,11 +842,17 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="20">
-         <label>"➡ 2. Does Jay like the following ice cream flavours?"</label>
+         <label>
+            <value>"➡ 2. Does Jay like the following ice cream flavours?"</value>
+            <type>VTL|MD</type>
+         </label>
          <declarations declarationType="STATEMENT"
                     id="d12-SI"
                     position="BEFORE_QUESTION_TEXT">
-            <label>"Now we are going to know if you think that Jay is a gluton."</label>
+            <label>
+               <value>"Now we are going to know if you think that Jay is a gluton."</value>
+               <type>VTL|MD</type>
+            </label>
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -593,7 +860,10 @@
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
@@ -603,16 +873,25 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Vanilla"</label>
+               <label>
+                  <value>"Vanilla"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5w99y" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR1"/>
                <bindingDependencies>ICE_FLAVOUR1</bindingDependencies>
@@ -621,16 +900,25 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Strawberry"</label>
+               <label>
+                  <value>"Strawberry"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5ummf" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR2"/>
                <bindingDependencies>ICE_FLAVOUR2</bindingDependencies>
@@ -639,16 +927,25 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Apple"</label>
+               <label>
+                  <value>"Apple"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5mry5" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR3"/>
                <bindingDependencies>ICE_FLAVOUR3</bindingDependencies>
@@ -657,16 +954,25 @@
          <cells type="line">
             <cells>
                <value>OT</value>
-               <label>"Other flavour"</label>
+               <label>
+                  <value>"Other flavour"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6p29i81-QOP-kiq5lkr8" componentType="Radio">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="ICE_FLAVOUR4"/>
                <bindingDependencies>ICE_FLAVOUR4</bindingDependencies>
@@ -679,14 +985,20 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="21">
-         <label>"➡ 3. Which character works in the nuclear power plant?"</label>
+         <label>
+            <value>"➡ 3. Which character works in the nuclear power plant?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
@@ -696,16 +1008,25 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Charles Montgomery Burns"</label>
+               <label>
+                  <value>"Charles Montgomery Burns"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewva8xg" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER1"/>
                <bindingDependencies>NUCLEAR_CHARACTER1</bindingDependencies>
@@ -714,16 +1035,25 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Carl Carlson"</label>
+               <label>
+                  <value>"Carl Carlson"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewvj0ad" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER2"/>
                <bindingDependencies>NUCLEAR_CHARACTER2</bindingDependencies>
@@ -732,16 +1062,25 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Otto Mann"</label>
+               <label>
+                  <value>"Otto Mann"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewveltm" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER3"/>
                <bindingDependencies>NUCLEAR_CHARACTER3</bindingDependencies>
@@ -750,16 +1089,25 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Lenny Leonard"</label>
+               <label>
+                  <value>"Lenny Leonard"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6qefnga-QOP-kewvgax4" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>0</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="NUCLEAR_CHARACTER4"/>
                <bindingDependencies>NUCLEAR_CHARACTER4</bindingDependencies>
@@ -772,14 +1120,20 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="22">
-         <label>"➡ 4. In which city each character was born?"</label>
+         <label>
+            <value>"➡ 4. In which city each character was born?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qe0h9q" page="18">
-               <label>"III - Characters"</label>
+               <label>
+                  <value>"III - Characters"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
@@ -790,28 +1144,46 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Selma Bouvier"</label>
+               <label>
+                  <value>"Selma Bouvier"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvjvcs" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER1"/>
                <bindingDependencies>BIRTH_CHARACTER1</bindingDependencies>
@@ -820,28 +1192,46 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Kent Brockman"</label>
+               <label>
+                  <value>"Kent Brockman"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvhoda" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER2"/>
                <bindingDependencies>BIRTH_CHARACTER2</bindingDependencies>
@@ -850,28 +1240,46 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Milhouse Van Houten"</label>
+               <label>
+                  <value>"Milhouse Van Houten"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewv64s5" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER3"/>
                <bindingDependencies>BIRTH_CHARACTER3</bindingDependencies>
@@ -880,28 +1288,46 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Nelson Muntz"</label>
+               <label>
+                  <value>"Nelson Muntz"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewvj21j" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER4"/>
                <bindingDependencies>BIRTH_CHARACTER4</bindingDependencies>
@@ -910,28 +1336,46 @@
          <cells type="line">
             <cells>
                <value>5</value>
-               <label>"Crazy Cat Lady"</label>
+               <label>
+                  <value>"Crazy Cat Lady"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="j6yzoc6g-QOP-kewva5uf" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Albuquerque"</label>
+                  <label>
+                     <value>"Albuquerque"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Springfield"</label>
+                  <label>
+                     <value>"Springfield"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Portland"</label>
+                  <label>
+                     <value>"Portland"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>4</value>
-                  <label>"Shelbyville"</label>
+                  <label>
+                     <value>"Shelbyville"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>5</value>
-                  <label>"Dagstuhl"</label>
+                  <label>
+                     <value>"Dagstuhl"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="BIRTH_CHARACTER5"/>
                <bindingDependencies>BIRTH_CHARACTER5</bindingDependencies>
@@ -942,14 +1386,20 @@
                componentType="Sequence"
                id="j4nw88h2"
                page="23">
-      <label>"IV - General questions"</label>
+      <label>
+         <value>"IV - General questions"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j4nw88h2" page="23">
-            <label>"IV - General questions"</label>
+            <label>
+               <value>"IV - General questions"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -957,17 +1407,26 @@
                componentType="Subsequence"
                id="j6qe237q"
                goToPage="24">
-      <label>"Kwik-E-Mart"</label>
+      <label>
+            <value>"Kwik-E-Mart"</value>
+            <type>VTL|MD</type>
+         </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qe237q" page="24">
-               <label>"Kwik-E-Mart"</label>
+               <label>
+                  <value>"Kwik-E-Mart"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
    </components>
@@ -977,17 +1436,26 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="24">
-            <label>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</label>
+            <label>
+               <value>"➡ 1. Please, specify the percentage of Jay’s expenses in the Kwik-E-Mart for each product?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
+                  <label>
+                     <value>"Kwik-E-Mart"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>PERCENTAGE_EXPENSES11</bindingDependencies>
@@ -999,20 +1467,32 @@
             <bindingDependencies>PERCENTAGE_EXPENSES71</bindingDependencies>
             <cells type="header">
                <cells headerCell="true" colspan="2">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Percentage"</label>
+                  <label>
+                     <value>"Percentage"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells rowspan="2">
                   <value>A</value>
-                  <label>"Frozen products"</label>
+                  <label>
+                     <value>"Frozen products"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>A1</value>
-                  <label>"Ice creams"</label>
+                  <label>
+                     <value>"Ice creams"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv2h3o"
                 componentType="InputNumber"
@@ -1027,7 +1507,10 @@
             <cells type="line">
                <cells>
                   <value>A2</value>
-                  <label>"Jasper Beardly"</label>
+                  <label>
+                     <value>"Jasper Beardly"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvka2j"
                 componentType="InputNumber"
@@ -1042,11 +1525,17 @@
             <cells type="line">
                <cells rowspan="3">
                   <value>B</value>
-                  <label>"Meat"</label>
+                  <label>
+                     <value>"Meat"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>B1</value>
-                  <label>"Bacon"</label>
+                  <label>
+                     <value>"Bacon"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv1f2a"
                 componentType="InputNumber"
@@ -1061,7 +1550,10 @@
             <cells type="line">
                <cells>
                   <value>B2</value>
-                  <label>"Pork chop"</label>
+                  <label>
+                     <value>"Pork chop"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvb2ql"
                 componentType="InputNumber"
@@ -1076,7 +1568,10 @@
             <cells type="line">
                <cells>
                   <value>B3</value>
-                  <label>"Chicken"</label>
+                  <label>
+                     <value>"Chicken"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvbxla"
                 componentType="InputNumber"
@@ -1091,11 +1586,17 @@
             <cells type="line">
                <cells>
                   <value>C</value>
-                  <label>"Compote"</label>
+                  <label>
+                     <value>"Compote"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>C1</value>
-                  <label>"Powersauce"</label>
+                  <label>
+                     <value>"Powersauce"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewvkjp0"
                 componentType="InputNumber"
@@ -1110,7 +1611,10 @@
             <cells type="line">
                <cells colspan="2">
                   <value>D</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j4nwc63q-QOP-kewv2cyx"
                 componentType="InputNumber"
@@ -1125,7 +1629,10 @@
             <cells type="line">
                <cells colspan="2">
                   <value>E</value>
-                  <label>"Total"</label>
+                  <label>
+                     <value>"Total"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="false"/>
             </cells>
@@ -1136,17 +1643,26 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="25">
-            <label>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</label>
+            <label>
+               <value>"➡ 2. Please specify if Jay has bought each product in his last food shopping"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qe237q" page="24">
-                  <label>"Kwik-E-Mart"</label>
+                  <label>
+                     <value>"Kwik-E-Mart"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
@@ -1159,33 +1675,54 @@
             <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
             <cells type="header">
                <cells headerCell="true" colspan="2">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"In his last food shopping"</label>
+                  <label>
+                     <value>"In his last food shopping"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells rowspan="2">
                   <value>A</value>
-                  <label>"Frozen products"</label>
+                  <label>
+                     <value>"Frozen products"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>A1</value>
-                  <label>"Ice creams"</label>
+                  <label>
+                     <value>"Ice creams"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6pljq" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING11"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING11</bindingDependencies>
@@ -1194,20 +1731,32 @@
             <cells type="line">
                <cells>
                   <value>A2</value>
-                  <label>"Jasper Beardly"</label>
+                  <label>
+                     <value>"Jasper Beardly"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6mgpv" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING21"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING21</bindingDependencies>
@@ -1216,24 +1765,39 @@
             <cells type="line">
                <cells rowspan="3">
                   <value>B</value>
-                  <label>"Meat"</label>
+                  <label>
+                     <value>"Meat"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>B1</value>
-                  <label>"Bacon"</label>
+                  <label>
+                     <value>"Bacon"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6pmtz" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING31"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING31</bindingDependencies>
@@ -1242,20 +1806,32 @@
             <cells type="line">
                <cells>
                   <value>B2</value>
-                  <label>"Pork chop"</label>
+                  <label>
+                     <value>"Pork chop"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6k4lf" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING41"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING41</bindingDependencies>
@@ -1264,20 +1840,32 @@
             <cells type="line">
                <cells>
                   <value>B3</value>
-                  <label>"Chicken"</label>
+                  <label>
+                     <value>"Chicken"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6p70n" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING51"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING51</bindingDependencies>
@@ -1286,24 +1874,39 @@
             <cells type="line">
                <cells>
                   <value>C</value>
-                  <label>"Compote"</label>
+                  <label>
+                     <value>"Compote"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells>
                   <value>C1</value>
-                  <label>"Powersauce"</label>
+                  <label>
+                     <value>"Powersauce"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6lh5v" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING61"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING61</bindingDependencies>
@@ -1312,20 +1915,32 @@
             <cells type="line">
                <cells colspan="2">
                   <value>D</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq703te" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING71"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING71</bindingDependencies>
@@ -1334,20 +1949,32 @@
             <cells type="line">
                <cells colspan="2">
                   <value>E</value>
-                  <label>"Total"</label>
+                  <label>
+                     <value>"Total"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="k9cg2q5t-QOP-kiq6zpd3" componentType="CheckboxOne">
                   <options>
                      <value>1</value>
-                     <label>"Yes"</label>
+                     <label>
+                        <value>"Yes"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"No"</label>
+                     <label>
+                        <value>"No"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="LAST_FOOD_SHOPPING81"/>
                   <bindingDependencies>LAST_FOOD_SHOPPING81</bindingDependencies>
@@ -1358,17 +1985,26 @@
                componentType="Subsequence"
                id="j6qejudb"
                goToPage="26">
-      <label>"Clowning"</label>
+      <label>
+            <value>"Clowning"</value>
+            <type>VTL|MD</type>
+         </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qejudb" page="26">
-               <label>"Clowning"</label>
+               <label>
+                  <value>"Clowning"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
    </components>
@@ -1378,17 +2014,26 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="26">
-            <label>"➡ 3. Who did these clownings and tell us what you remember?"</label>
+            <label>
+               <value>"➡ 3. Who did these clownings and tell us what you remember?"</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qejudb" page="26">
-                  <label>"Clowning"</label>
+                  <label>
+                     <value>"Clowning"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>CLOWNING11</bindingDependencies>
@@ -1401,36 +2046,60 @@
             <bindingDependencies>CLOWNING42</bindingDependencies>
             <cells type="header">
                <cells headerCell="true">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Clowning"</label>
+                  <label>
+                     <value>"Clowning"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Remember?"</label>
+                  <label>
+                     <value>"Remember?"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells>
                   <value>1</value>
-                  <label>"Break the windows of the whole city"</label>
+                  <label>
+                     <value>"Break the windows of the whole city"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6m5n0" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING11"/>
                   <bindingDependencies>CLOWNING11</bindingDependencies>
@@ -1443,24 +2112,39 @@
             <cells type="line">
                <cells>
                   <value>2</value>
-                  <label>"Loose the violin of his daughter playing poker"</label>
+                  <label>
+                     <value>"Loose the violin of his daughter playing poker"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6l29o" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING21"/>
                   <bindingDependencies>CLOWNING21</bindingDependencies>
@@ -1473,24 +2157,39 @@
             <cells type="line">
                <cells>
                   <value>3</value>
-                  <label>"Kill Mr Burns"</label>
+                  <label>
+                     <value>"Kill Mr Burns"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq72biw" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING31"/>
                   <bindingDependencies>CLOWNING31</bindingDependencies>
@@ -1503,24 +2202,39 @@
             <cells type="line">
                <cells>
                   <value>4</value>
-                  <label>"Leaving a mechanical object to control the nuclear power plant"</label>
+                  <label>
+                     <value>"Leaving a mechanical object to control the nuclear power plant"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="kbkjvgel-QOP-kiq6mlan" componentType="Dropdown">
                   <options>
                      <value>1</value>
-                     <label>"Jay"</label>
+                     <label>
+                        <value>"Jay"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>2</value>
-                     <label>"Bart"</label>
+                     <label>
+                        <value>"Bart"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>3</value>
-                     <label>"Krusty the clown"</label>
+                     <label>
+                        <value>"Krusty the clown"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <options>
                      <value>O</value>
-                     <label>"Other"</label>
+                     <label>
+                        <value>"Other"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </options>
                   <response name="CLOWNING41"/>
                   <bindingDependencies>CLOWNING41</bindingDependencies>
@@ -1535,17 +2249,26 @@
                componentType="Subsequence"
                id="j6qeh91y"
                goToPage="27">
-      <label>"Transport"</label>
+      <label>
+            <value>"Transport"</value>
+            <type>VTL|MD</type>
+         </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
             <sequence id="j4nw88h2" page="23">
-               <label>"IV - General questions"</label>
+               <label>
+                  <value>"IV - General questions"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
             <subSequence id="j6qeh91y" page="27">
-               <label>"Transport"</label>
+               <label>
+                  <value>"Transport"</value>
+                  <type>VTL|MD</type>
+               </label>
             </subSequence>
          </hierarchy>
    </components>
@@ -1555,11 +2278,17 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="27">
-            <label>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</label>
+            <label>
+               <value>"➡ 4. Which of the following means of transport were used by the hero and in which country?"</value>
+               <type>VTL|MD</type>
+            </label>
             <declarations declarationType="INSTRUCTION"
                     id="j6p2lwuj-d10"
                     position="AFTER_QUESTION_TEXT">
-               <label>"Several answers possible: check off all the relevant boxes"</label>
+               <label>
+                  <value>"Several answers possible: check off all the relevant boxes"</value>
+                  <type>VTL|MD</type>
+               </label>
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
@@ -1567,10 +2296,16 @@
             </conditionFilter>
             <hierarchy>
                <sequence id="j4nw88h2" page="23">
-                  <label>"IV - General questions"</label>
+                  <label>
+                     <value>"IV - General questions"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="j6qeh91y" page="27">
-                  <label>"Transport"</label>
+                  <label>
+                     <value>"Transport"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
             <bindingDependencies>TRAVEL11</bindingDependencies>
@@ -1599,31 +2334,55 @@
             <bindingDependencies>TRAVEL46</bindingDependencies>
             <cells type="header">
                <cells headerCell="true">
-                  <label/>
+                  <label>
+                     <value/>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Brazil"</label>
+                  <label>
+                     <value>"Brazil"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Canada"</label>
+                  <label>
+                     <value>"Canada"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Japan"</label>
+                  <label>
+                     <value>"Japan"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"France"</label>
+                  <label>
+                     <value>"France"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Other country"</label>
+                  <label>
+                     <value>"Other country"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells headerCell="true">
-                  <label>"Other planet"</label>
+                  <label>
+                     <value>"Other planet"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
             </cells>
             <cells type="line">
                <cells>
                   <value>1</value>
-                  <label>"Car"</label>
+                  <label>
+                     <value>"Car"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvm4qg" componentType="CheckboxBoolean">
                   <response name="TRAVEL11"/>
@@ -1653,7 +2412,10 @@
             <cells type="line">
                <cells>
                   <value>2</value>
-                  <label>"Bike"</label>
+                  <label>
+                     <value>"Bike"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvebem" componentType="CheckboxBoolean">
                   <response name="TRAVEL21"/>
@@ -1683,7 +2445,10 @@
             <cells type="line">
                <cells>
                   <value>3</value>
-                  <label>"Skateboard"</label>
+                  <label>
+                     <value>"Skateboard"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewv62xx" componentType="CheckboxBoolean">
                   <response name="TRAVEL31"/>
@@ -1713,7 +2478,10 @@
             <cells type="line">
                <cells>
                   <value>4</value>
-                  <label>"Plane"</label>
+                  <label>
+                     <value>"Plane"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </cells>
                <cells id="j6p2lwuj-QOP-kewvjcck" componentType="CheckboxBoolean">
                   <response name="TRAVEL41"/>
@@ -1745,14 +2513,20 @@
                componentType="Sequence"
                id="j6qfx9qe"
                page="28">
-      <label>"V - Favourite characters (dynamic table)"</label>
+      <label>
+         <value>"V - Favourite characters (dynamic table)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6qfx9qe" page="28">
-            <label>"V - Favourite characters (dynamic table)"</label>
+            <label>
+               <value>"V - Favourite characters (dynamic table)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -1762,14 +2536,20 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="29">
-         <label>"➡ 1. Please, complete the following grid with your favourite characters"</label>
+         <label>
+            <value>"➡ 1. Please, complete the following grid with your favourite characters"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>FAVOURITE_CHAR1</bindingDependencies>
@@ -1808,13 +2588,22 @@
          <lines min="1" max="10"/>
          <cells type="header">
             <cells headerCell="true">
-               <label>"Name"</label>
+               <label>
+                  <value>"Name"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Age"</label>
+               <label>
+                  <value>"Age"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Member of the Simpsons family"</label>
+               <label>
+                  <value>"Member of the Simpsons family"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
          </cells>
          <cells type="line">
@@ -1833,15 +2622,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_1_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_1_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_1_3</bindingDependencies>
@@ -1863,15 +2661,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_2_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_2_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_2_3</bindingDependencies>
@@ -1893,15 +2700,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_3_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_3_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_3_3</bindingDependencies>
@@ -1923,15 +2739,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_4_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_4_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_4_3</bindingDependencies>
@@ -1953,15 +2778,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_5_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_5_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_5_3</bindingDependencies>
@@ -1983,15 +2817,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_6_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_6_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_6_3</bindingDependencies>
@@ -2013,15 +2856,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_7_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_7_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_7_3</bindingDependencies>
@@ -2043,15 +2895,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_8_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_8_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_8_3</bindingDependencies>
@@ -2073,15 +2934,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_9_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_9_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_9_3</bindingDependencies>
@@ -2103,15 +2973,24 @@
             <cells id="j6qg8rc6-QOP-kiq7lffy_10_3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Yes"</label>
+                  <label>
+                     <value>"Yes"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"No"</label>
+                  <label>
+                     <value>"No"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Other"</label>
+                  <label>
+                     <value>"Other"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FAVOURITE_CHAR3_10_3"/>
                <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
@@ -2124,14 +3003,20 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="30">
-         <label>"➡ 2. How has your feeling about the following characters evolved over time?"</label>
+         <label>
+            <value>"➡ 2. How has your feeling about the following characters evolved over time?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>FEELCHAREV1</bindingDependencies>
@@ -2141,20 +3026,32 @@
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Jay"</label>
+               <label>
+                  <value>"Jay"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq76emy" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV1"/>
                <bindingDependencies>FEELCHAREV1</bindingDependencies>
@@ -2163,20 +3060,32 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Bart"</label>
+               <label>
+                  <value>"Bart"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq6zv60" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV2"/>
                <bindingDependencies>FEELCHAREV2</bindingDependencies>
@@ -2185,20 +3094,32 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Krusty the clown"</label>
+               <label>
+                  <value>"Krusty the clown"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq7bgk3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV3"/>
                <bindingDependencies>FEELCHAREV3</bindingDependencies>
@@ -2207,20 +3128,32 @@
          <cells type="line">
             <cells>
                <value>O</value>
-               <label>"Other"</label>
+               <label>
+                  <value>"Other"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxux0mi-QOP-kiq6ync3" componentType="CheckboxOne">
                <options>
                   <value>1</value>
-                  <label>"Up"</label>
+                  <label>
+                     <value>"Up"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Down"</label>
+                  <label>
+                     <value>"Down"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>3</value>
-                  <label>"Steady"</label>
+                  <label>
+                     <value>"Steady"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="FEELCHAREV4"/>
                <bindingDependencies>FEELCHAREV4</bindingDependencies>
@@ -2233,14 +3166,20 @@
                positioning="HORIZONTAL"
                mandatory="false"
                page="31">
-         <label>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</label>
+         <label>
+            <value>"➡ 3. Can you tell how long Bart Simpson has been on leave for each type and whether there has been another type?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6qfx9qe" page="28">
-               <label>"V - Favourite characters (dynamic table)"</label>
+               <label>
+                  <value>"V - Favourite characters (dynamic table)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>LEAVDURATION11</bindingDependencies>
@@ -2255,19 +3194,31 @@
          <bindingDependencies>LEAVDURATION52</bindingDependencies>
          <cells type="header">
             <cells headerCell="true">
-               <label/>
+               <label>
+                  <value/>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Days"</label>
+               <label>
+                  <value>"Days"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells headerCell="true">
-               <label>"Unit"</label>
+               <label>
+                  <value>"Unit"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
          </cells>
          <cells type="line">
             <cells>
                <value>1</value>
-               <label>"Leave with pay"</label>
+               <label>
+                  <value>"Leave with pay"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv511d"
                 componentType="InputNumber"
@@ -2280,11 +3231,17 @@
             <cells id="jvxwy68n-QOP-kewv20qg" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION12"/>
                <bindingDependencies>LEAVDURATION12</bindingDependencies>
@@ -2293,7 +3250,10 @@
          <cells type="line">
             <cells>
                <value>2</value>
-               <label>"Public holiday"</label>
+               <label>
+                  <value>"Public holiday"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv67nj"
                 componentType="InputNumber"
@@ -2306,11 +3266,17 @@
             <cells id="jvxwy68n-QOP-kewvizdm" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION22"/>
                <bindingDependencies>LEAVDURATION22</bindingDependencies>
@@ -2319,7 +3285,10 @@
          <cells type="line">
             <cells>
                <value>3</value>
-               <label>"Sick leave"</label>
+               <label>
+                  <value>"Sick leave"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv23wm"
                 componentType="InputNumber"
@@ -2332,11 +3301,17 @@
             <cells id="jvxwy68n-QOP-kewv9jcl" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION32"/>
                <bindingDependencies>LEAVDURATION32</bindingDependencies>
@@ -2345,7 +3320,10 @@
          <cells type="line">
             <cells>
                <value>4</value>
-               <label>"Maternity/paternity leave"</label>
+               <label>
+                  <value>"Maternity/paternity leave"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewv2jks"
                 componentType="InputNumber"
@@ -2358,11 +3336,17 @@
             <cells id="jvxwy68n-QOP-kewvf0gf" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION42"/>
                <bindingDependencies>LEAVDURATION42</bindingDependencies>
@@ -2371,7 +3355,10 @@
          <cells type="line">
             <cells>
                <value>5</value>
-               <label>"Other type"</label>
+               <label>
+                  <value>"Other type"</value>
+                  <type>VTL|MD</type>
+               </label>
             </cells>
             <cells id="jvxwy68n-QOP-kewvl896"
                 componentType="InputNumber"
@@ -2384,11 +3371,17 @@
             <cells id="jvxwy68n-QOP-kewvalmd" componentType="Dropdown">
                <options>
                   <value>1</value>
-                  <label>"Working Days"</label>
+                  <label>
+                     <value>"Working Days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <options>
                   <value>2</value>
-                  <label>"Calendar days"</label>
+                  <label>
+                     <value>"Calendar days"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </options>
                <response name="LEAVDURATION52"/>
                <bindingDependencies>LEAVDURATION52</bindingDependencies>
@@ -2399,14 +3392,20 @@
                componentType="Sequence"
                id="kiq5mr0b"
                page="32">
-      <label>"VI - Favourite characters (Loop)"</label>
+      <label>
+         <value>"VI - Favourite characters (Loop)"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
          <sequence id="kiq5mr0b" page="32">
-            <label>"VI - Favourite characters (Loop)"</label>
+            <label>
+               <value>"VI - Favourite characters (Loop)"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -2418,14 +3417,20 @@
                max="20"
                decimals="0"
                page="33">
-         <label>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</label>
+         <label>
+            <value>"➡ 1. How many characters from the Simpsons family could you precisely describe?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NB_CHAR</bindingDependencies>
@@ -2436,14 +3441,20 @@
                id="kiq7bjam"
                page="34"
                paginatedLoop="false">
-         <label>"Add a character"</label>
+         <label>
+            <value>"Add a character"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5mr0b" page="32">
-               <label>"VI - Favourite characters (Loop)"</label>
+               <label>
+                  <value>"VI - Favourite characters (Loop)"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2453,17 +3464,26 @@
                   id="kiq5u8d5"
                   page="34"
                   goToPage="34">
-         <label>"Description of each character"</label>
+         <label>
+               <value>"Description of each character"</value>
+               <type>VTL|MD</type>
+            </label>
          <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
          <hierarchy>
                <sequence id="kiq5mr0b" page="32">
-                  <label>"VI - Favourite characters (Loop)"</label>
+                  <label>
+                     <value>"VI - Favourite characters (Loop)"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
                <subSequence id="kiq5u8d5" page="34">
-                  <label>"Description of each character"</label>
+                  <label>
+                     <value>"Description of each character"</value>
+                     <type>VTL|MD</type>
+                  </label>
                </subSequence>
             </hierarchy>
       </components>
@@ -2473,17 +3493,26 @@
                   maxLength="30"
                   mandatory="false"
                   page="34">
-               <label>"➡ 2. What is the first name of this character?"</label>
+               <label>
+                  <value>"➡ 2. What is the first name of this character?"</value>
+                  <type>VTL|MD</type>
+               </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
                   <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
+                     <label>
+                        <value>"VI - Favourite characters (Loop)"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </sequence>
                   <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
+                     <label>
+                        <value>"Description of each character"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </subSequence>
                </hierarchy>
                <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2497,17 +3526,26 @@
                   max="120"
                   decimals="0"
                   page="34">
-               <label>"➡ 3. How old is this character in the first episode of the Simpsons family?"</label>
+               <label>
+                  <value>"➡ 3. How old is this character in the first episode of the Simpsons family?"</value>
+                  <type>VTL|MD</type>
+               </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
                   <sequence id="kiq5mr0b" page="32">
-                     <label>"VI - Favourite characters (Loop)"</label>
+                     <label>
+                        <value>"VI - Favourite characters (Loop)"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </sequence>
                   <subSequence id="kiq5u8d5" page="34">
-                     <label>"Description of each character"</label>
+                     <label>
+                        <value>"Description of each character"</value>
+                        <type>VTL|MD</type>
+                     </label>
                   </subSequence>
                </hierarchy>
                <bindingDependencies>AGE_CHAR</bindingDependencies>
@@ -2535,14 +3573,20 @@
                   componentType="Sequence"
                   id="kiq5xw5p"
                   page="35.1">
-         <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+         <label>
+            <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
             <sequence id="kiq5xw5p" page="35.1">
-               <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+               <label>
+                  <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2552,25 +3596,37 @@
                   id="kiq65x3c"
                   mandatory="false"
                   page="35.2">
-            <label>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</label>
+            <label>
+               <value>"➡ 1. Is character named " || cast(cast(NAME_CHAR,string),string) || " your favourite one ? "</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+                  <label>
+                     <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
             </hierarchy>
             <bindingDependencies>NAME_CHAR</bindingDependencies>
             <bindingDependencies>FAVCHAR</bindingDependencies>
             <options>
                <value>1</value>
-               <label>"Yes"</label>
+               <label>
+                  <value>"Yes"</value>
+                  <type>VTL|MD</type>
+               </label>
             </options>
             <options>
                <value>0</value>
-               <label>"No"</label>
+               <label>
+                  <value>"No"</value>
+                  <type>VTL|MD</type>
+               </label>
             </options>
             <response name="FAVCHAR"/>
          </components>
@@ -2580,14 +3636,20 @@
                   maxLength="255"
                   mandatory="false"
                   page="35.3">
-            <label>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</label>
+            <label>
+               <value>"➡ 2. What is your best memory about character named " || cast(cast(NAME_CHAR,string),string) || " ? "</value>
+               <type>VTL|MD</type>
+            </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
                <sequence id="kiq5xw5p" page="35.1">
-                  <label>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</label>
+                  <label>
+                     <value>"VII - Other details about character named " || cast(cast(NAME_CHAR,string),string) || " "</value>
+                     <type>VTL|MD</type>
+                  </label>
                </sequence>
             </hierarchy>
             <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -2599,13 +3661,19 @@
                componentType="Sequence"
                id="j6z12s2d"
                page="36">
-      <label>"VIII - Comment"</label>
+      <label>
+         <value>"VIII - Comment"</value>
+         <type>VTL|MD</type>
+      </label>
       <conditionFilter>
          <value>true</value>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
-            <label>"VIII - Comment"</label>
+            <label>
+               <value>"VIII - Comment"</value>
+               <type>VTL|MD</type>
+            </label>
          </sequence>
       </hierarchy>
    </components>
@@ -2615,13 +3683,19 @@
                maxLength="255"
                mandatory="false"
                page="37">
-         <label>"➡ 1. Do you have any comment about the survey?"</label>
+         <label>
+            <value>"➡ 1. Do you have any comment about the survey?"</value>
+            <type>VTL|MD</type>
+         </label>
          <conditionFilter>
             <value>true</value>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6z12s2d" page="36">
-               <label>"VIII - Comment"</label>
+               <label>
+                  <value>"VIII - Comment"</value>
+                  <type>VTL|MD</type>
+               </label>
             </sequence>
          </hierarchy>
          <bindingDependencies>SURVEY_COMMENT</bindingDependencies>

--- a/src/test/resources/examples/xmlh-2-xmlf/out.xml
+++ b/src/test/resources/examples/xmlh-2-xmlf/out.xml
@@ -3610,10 +3610,6 @@
                page="35"
                maxPage="3"
                paginatedLoop="true">
-      <iterations>
-         <value>count(NAME_CHAR)</value>
-         <type>VTL|MD</type>
-      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
          <type>VTL|MD</type>
@@ -3714,6 +3710,10 @@
             <bindingDependencies>MEMORY_CHAR</bindingDependencies>
             <response name="MEMORY_CHAR"/>
          </components>
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
    </components>
    <components xsi:type="Sequence"
                componentType="Sequence"

--- a/src/test/resources/examples/xmlh-2-xmlf/out.xml
+++ b/src/test/resources/examples/xmlh-2-xmlf/out.xml
@@ -28,6 +28,7 @@
       </declarations>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6p0ti5h" page="1">
@@ -50,6 +51,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -81,6 +83,7 @@
          </declarations>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -104,6 +107,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6p0ti5h" page="1">
@@ -124,6 +128,7 @@
          </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
@@ -153,6 +158,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -186,6 +192,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -226,6 +233,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -266,6 +274,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -307,6 +316,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -341,6 +351,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -375,6 +386,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -409,6 +421,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -443,6 +456,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -477,6 +491,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -515,6 +530,7 @@
       </declarations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -545,6 +561,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -598,6 +615,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -650,6 +668,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -764,6 +783,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -793,6 +813,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -856,6 +877,7 @@
          </declarations>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -991,6 +1013,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -1126,6 +1149,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -1392,6 +1416,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -1413,6 +1438,7 @@
          </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
@@ -1442,6 +1468,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -1649,6 +1676,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -1991,6 +2019,7 @@
          </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
@@ -2020,6 +2049,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -2255,6 +2285,7 @@
          </label>
       <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
       <hierarchy>
@@ -2292,6 +2323,7 @@
             </declarations>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -2519,6 +2551,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -2542,6 +2575,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -2585,7 +2619,16 @@
          <bindingDependencies>FAVOURITE_CHAR1_10_1</bindingDependencies>
          <bindingDependencies>FAVOURITE_CHAR2_10_2</bindingDependencies>
          <bindingDependencies>FAVOURITE_CHAR3_10_3</bindingDependencies>
-         <lines min="1" max="10"/>
+         <lines>
+            <min>
+               <value>1</value>
+               <type>VTL|MD</type>
+            </min>
+            <max>
+               <value>10</value>
+               <type>VTL|MD</type>
+            </max>
+         </lines>
          <cells type="header">
             <cells headerCell="true">
                <label>
@@ -3009,6 +3052,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3172,6 +3216,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3398,6 +3443,7 @@
       </label>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <hierarchy>
@@ -3423,6 +3469,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3447,6 +3494,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3470,6 +3518,7 @@
             </label>
          <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
          <hierarchy>
@@ -3499,6 +3548,7 @@
                </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+                  <type>VTL|MD</type>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
@@ -3532,6 +3582,7 @@
                </label>
                <conditionFilter>
                   <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+                  <type>VTL|MD</type>
                   <bindingDependencies>READY</bindingDependencies>
                </conditionFilter>
                <hierarchy>
@@ -3556,12 +3607,16 @@
                componentType="Loop"
                id="kiq7cbgo"
                depth="1"
-               iterations="count(NAME_CHAR)"
                page="35"
                maxPage="3"
                paginatedLoop="true">
+      <iterations>
+         <value>count(NAME_CHAR)</value>
+         <type>VTL|MD</type>
+      </iterations>
       <conditionFilter>
          <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+         <type>VTL|MD</type>
          <bindingDependencies>READY</bindingDependencies>
       </conditionFilter>
       <bindingDependencies>NAME_CHAR</bindingDependencies>
@@ -3579,6 +3634,7 @@
          </label>
          <conditionFilter>
             <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+            <type>VTL|MD</type>
             <bindingDependencies>READY</bindingDependencies>
          </conditionFilter>
          <hierarchy>
@@ -3602,6 +3658,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -3642,6 +3699,7 @@
             </label>
             <conditionFilter>
                <value>(not(cast(READY,integer)  &lt;&gt;  1))</value>
+               <type>VTL|MD</type>
                <bindingDependencies>READY</bindingDependencies>
             </conditionFilter>
             <hierarchy>
@@ -3667,6 +3725,7 @@
       </label>
       <conditionFilter>
          <value>true</value>
+         <type>VTL|MD</type>
       </conditionFilter>
       <hierarchy>
          <sequence id="j6z12s2d" page="36">
@@ -3689,6 +3748,7 @@
          </label>
          <conditionFilter>
             <value>true</value>
+            <type>VTL|MD</type>
          </conditionFilter>
          <hierarchy>
             <sequence id="j6z12s2d" page="36">


### PR DESCRIPTION
Evolutions asked by Lunatic :
- Adding a cleaning block at the end of Lunatic questionnaire format that should contain for each variable likely to launch the cleaning of other variables (typically a variable appearing in a filter condition) the list of variables that would need to be cleaned
- Transforming the label element which contained a string potentially representing a VTL and/or MD expression into a label object which contains an expression element and a type element that can be "STRING", "VTL", "MD" or "VTL|MD"