### PR TITLE
Dev lunatic format control type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.14-rc</version>
+	<version>2.3.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.13</version>
+	<version>2.2.14-rc</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -537,7 +537,6 @@
             <xs:enumeration value="DETACHABLE"/>
         </xs:restriction>
     </xs:simpleType>
-
     <xs:complexType name="ControlType">
         <xs:sequence>
             <xs:element name="control" type="labelType"/>
@@ -545,6 +544,7 @@
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" />
+        <xs:attribute name="typeOfControl" type="ControlTypeOfControlEnum"/>
         <xs:attribute name="criticality" type="ControlCriticityEnum"/>
     </xs:complexType>
     <xs:simpleType name="ControlCriticityEnum">
@@ -552,6 +552,12 @@
             <xs:enumeration value="INFO"/>
             <xs:enumeration value="WARN"/>
             <xs:enumeration value="ERROR"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ControlTypeOfControlEnum">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="FORMAT"/>
+            <xs:enumeration value="COHERENCE"/>
         </xs:restriction>
     </xs:simpleType>
     

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -557,7 +557,7 @@
     <xs:simpleType name="ControlTypeOfControlEnum">
         <xs:restriction base="xs:token">
             <xs:enumeration value="FORMAT"/>
-            <xs:enumeration value="COHERENCE"/>
+            <xs:enumeration value="CONSISTENCY"/>
         </xs:restriction>
     </xs:simpleType>
     

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -540,6 +540,7 @@
             <xs:element name="bindingDependencies" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="id" type="xs:ID" />
+        <xs:attribute name="typeOfControl" type="ControlTypeOfControlEnum"/>
         <xs:attribute name="criticality" type="ControlCriticityEnum"/>
     </xs:complexType>
     <xs:simpleType name="ControlCriticityEnum">
@@ -547,6 +548,12 @@
             <xs:enumeration value="INFO"/>
             <xs:enumeration value="WARN"/>
             <xs:enumeration value="ERROR"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="ControlTypeOfControlEnum">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="FORMAT"/>
+            <xs:enumeration value="COHERENCE"/>
         </xs:restriction>
     </xs:simpleType>
     

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -553,7 +553,7 @@
     <xs:simpleType name="ControlTypeOfControlEnum">
         <xs:restriction base="xs:token">
             <xs:enumeration value="FORMAT"/>
-            <xs:enumeration value="COHERENCE"/>
+            <xs:enumeration value="CONSISTENCY"/>
         </xs:restriction>
     </xs:simpleType>
     


### PR DESCRIPTION
#### Contrôles

Les contrôles de formats sont désormais portés par le modèle (Eno les ajoute à partir des métadonnées décrites dans Pogues. Exemple : min, max, nombre de décimales). 
Les contrôles de format (standardisés) sont les suivants : 
- Pour les nombres : vérification du nombre de décimales et des bornes
- Pour les dates : vérification des bornes


Un typage de contrôle `typeOfControl` a été ajouté. Les valeurs possibles sont : 
- `FORMAT` (contrôle de format ajouté par Eno non modifiable) 
- `CONSISTENCY` (contrôle métier saisi dans Pogues)

Exemple : 

***Lunatic V2 :*** 
```json
    "controls" : 
    [ 
     { "id" : "k5nw0w05-format-borne-inf-sup",
      "typeOfControl" : "FORMAT",
      "criticality" : "ERROR",
      "control" : 
      { "value" : "not(not(isnull(DURATIONH)) and (0.00>DURATIONH or 70.00<DURATIONH))",
       "type" : "VTL" },
      "errorMessage" : 
      { "value" : "\" La valeur doit être comprise entre 0.00 et 70.00.\"",
       "type" : "VTL|MD" } },
     
     { "id" : "k5nw0w05-format-decimal",
      "typeOfControl" : "FORMAT",
      "criticality" : "ERROR",
      "control" : 
      { "value" : "not(not(isnull(DURATIONH))  and round(DURATIONH,2)<>DURATIONH)",
       "type" : "VTL" },
      "errorMessage" : 
      { "value" : "\"Le nombre doit comporter au maximum 2 chiffre(s) après la virgule.\"",
       "type" : "VTL|MD" } }
```
	    

#### Ajout d'un type pour les objets pouvant contenir du texte ou des formules VTL


Tous les objets pouvant contenir du texte et du VTL (de type `label`, `control`, `errorMessage`, `expression`, `conditionFilter`, `iterations`, `min` et `max` des "lines" des Loop)  passent de `string` ou `value` à un  duo `type/value`.

Les type permettront à terme la valorisation par `STRING`, `VTL`, `MD`, `VTL|MD`.
Cela a été mis en place afin de remédier aux exécutions inutiles VTL ou markdown. 
(Pas encore mis en oeuvre côté lib. A utiliser `VTL` et `VTL|MD`)

*Exemple :* 

***Lunatic V1 :***
```json
"label": "Hello"
```
***Lunatic V2 :*** 
```json
"label": {
    "value": "Hello",
    "type": "VTL|MD"
}
```

#### Bloc `cleaning` à la racine

Ce nouveau bloc ajouté à la racine du json Lunatic sert à gérer le “vidage” des variables sans objet (ie appartenant à des questions non filtrées puis filtrées).

Ce bloc se présente comme la liste des variables dépendant d'une variable sur laquelle porte un filtre. L'expression de la condition du filtre (et donc du maintien de la variable) est donnée. 

Exemple : Ici un filtre dépend d'une variable : si `COCHECASE = true`, alors les questions dont les variables sont `TABLEAU2A41`, `TABLEAU2A42`, `BOOLEN` et `UNITD` s'affichent. 

Exemple : 

***Lunatic V2*** 
```json 
    "cleaning": {
        "COCHECASE": {
            "TABLEAU2A41": "(COCHECASE = true)",
            "TABLEAU2A42": "(COCHECASE = true)",
            "BOOLEN": "(COCHECASE = true)",
            "UNITD": "(COCHECASE = true)",
        }
    }
```

#### Block `missingBlock` à la racine
Ce block résume les liens entre response et missing response

#### Block `resizing` à la racine

Ce nouveau bloc ajouté à la racine permet de "retailler des vecteurs de boucle en fonction de ce qui instancie ces boucles (vecteur ou itération).

Il se présente comme une liste de variables permettant de calculer une taille de boucle et pour chacune, la liste des variables impactées et la longueur effective.

*Exemple :*

***Lunatic V2 :*** 
```json
 "resizing" : 
  { "NB_CHAR" : 
   { "size" : "cast(NB_CHAR,integer)",
    "variables" : 
    [ "NAME_CHAR",
     "AGE_CHAR" ] },
   "NAME_CHAR" : 
   { "size" : "count(NAME_CHAR)",
    "variables" : 
    [ "FAVCHAR",
     "MEMORY_CHAR" ] } }
```



#### Tableau

Pour les `Table`, plus un unique parent`cells` contenant au début des `headerCell` le cas échéant mais un découpage `header` et `body`.

Exemple : 

***Lunatic V1***
```json 
   { "id" : "kbkjvgel",
    "componentType" : "Table",
    ...
    "cells" : 
    [ 
     [ 
      { "headerCell" : true,
       "label" : "" },
      
      { "headerCell" : true,
       "label" : "Clowning" },
      
      { "headerCell" : true,
       "label" : "Remember?" } ],
     
     [ 
      { "value" : "1",
       "label" : "***Break the windows of the whole city***" },
      ...
```

***Lunatic V2***
```json 
   { "id" : "kbkjvgel",
    "componentType" : "Table",
    ...
    "header" : 
    [ 
     { "label" : 
      { "value" : "",
       "type" : "VTL|MD" } },
     
     { "label" : 
      { "value" : "Clowning",
       "type" : "VTL|MD" } },
     
     { "label" : 
      { "value" : "Remember?",
       "type" : "VTL|MD" } } ],
    "body" : 
    [ 
     [ 
      { "value" : "1",
       "label" : 
       { "value" : "***Break the windows of the whole city***",
        "type" : "VTL|MD" } },
      ...
```

#### Variables

Disparition de l'attribut `componentRef`

*Exemple :* 

***Lunatic V1***

```json 
  { "variableType" : "COLLECTED",
    "name" : "COMMENT_QE",
    "componentRef" : "COMMENT-QUESTION",
    "values" : 
    { "PREVIOUS" : null,
     "COLLECTED" : null,
     "FORCED" : null,
     "EDITED" : null,
     "INPUTED" : null } }
```

***Lunatic V2***

```json 
  { "variableType" : "COLLECTED",
    "name" : "COMMENT_QE",
    "values" : 
    { "PREVIOUS" : null,
     "COLLECTED" : null,
     "FORCED" : null,
     "EDITED" : null,
     "INPUTED" : null } }
```

#### Changement dans la lib Lunatic-model

L'étape json-cleaner a été mise à jour pour prendre en compte les nouveautés . Pour rappel, cette étape technique permet de "nettoyer" le XML pour obtenir ce que l'on souhaite en Json lorsque c'est non modélisable en XSD ou pas exactement ce qu'il y a dans le XML.


