### PR TITLE
[Dev pairwise] Restore "components" in "PairwiseLinks"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>2.3.2-rc3</version>
+	<version>2.3.2-rc4</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/resources/xsd/LunaticModel.xsd
+++ b/src/main/resources/xsd/LunaticModel.xsd
@@ -123,6 +123,7 @@
                 <xs:sequence>
                     <xs:element name="xAxisIterations" type="labelType" minOccurs="0"/>
                     <xs:element name="yAxisIterations" type="labelType" minOccurs="0"/>
+                    <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="symLinks" type="symLinksType" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>

--- a/src/main/resources/xsd/LunaticModelFlat.xsd
+++ b/src/main/resources/xsd/LunaticModelFlat.xsd
@@ -117,6 +117,7 @@
                 <xs:sequence>
                     <xs:element name="xAxisIterations" type="labelType" minOccurs="0"/>
                     <xs:element name="yAxisIterations" type="labelType" minOccurs="0"/>
+                    <xs:element name="components" type="ComponentType" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="symLinks" type="symLinksType" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>


### PR DESCRIPTION
If [Lunatic spec on "pairwise links"](https://github.com/InseeFr/Lunatic/blob/v2-master/src/stories/pairwise/links.json) is up-to-date, "PairwiseLinks" requires a "components" list.

This list is currently missing (maybe just an oversight during "symLinks" implementation https://github.com/InseeFr/Lunatic-Model/commit/969c3e9a2f0a88c79ad84d20b4cc85641fbe0954).
