### PR TITLE
Feat/serializer for eno3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>2.3.2-rc4</version>
+	<version>2.3.2-rc5</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/java/fr/insee/lunatic/conversion/JSONSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/JSONSerializer.java
@@ -1,17 +1,20 @@
 package fr.insee.lunatic.conversion;
 
-import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.eclipse.persistence.jaxb.MarshallerProperties;
-
-import fr.insee.lunatic.model.flat.Questionnaire;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 public class JSONSerializer {
 
@@ -37,8 +40,36 @@ public class JSONSerializer {
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		marshaller.marshal(questionnaire, baos);
-	
+
 		return baos.toString("UTF-8");
 
+	}
+
+	/** <code>serialize</code> method returns a json string beginning with {"Questionnaire": {...}}.
+	 * The need is to actually have questionnaire content directly at the root of the json tree.
+	 * This method returns the json content of the given questionnaire without the "Questionnaire" level.
+	 * @param questionnaire Lunatic questionnaire object (flat model).
+	 * @return The questionnaire as a json string.
+	 */
+	public String serialize2(Questionnaire questionnaire) throws SerializationException {
+		//
+		String questionnaireString;
+		try {
+			questionnaireString = serialize(questionnaire);
+		} catch (JAXBException | UnsupportedEncodingException e) {
+			throw new SerializationException("Error when calling first serialize method.", e);
+		}
+		//
+		try (JsonReader jsonReader = Json.createReader(
+				new ByteArrayInputStream(questionnaireString.getBytes(StandardCharsets.UTF_8)));
+			 OutputStream outputStream = new ByteArrayOutputStream();
+			 JsonWriter jsonWriter = Json.createWriter(outputStream)) {
+			JsonObject questionnaireJson = jsonReader.readObject();
+			JsonObject contentJson = questionnaireJson.getJsonObject("Questionnaire");
+			jsonWriter.writeObject(contentJson);
+			return outputStream.toString();
+		} catch (IOException e) {
+			throw new SerializationException("Error when removing \"Questionnaire\" level of given questionnaire.", e);
+		}
 	}
 }

--- a/src/main/java/fr/insee/lunatic/exception/SerializationException.java
+++ b/src/main/java/fr/insee/lunatic/exception/SerializationException.java
@@ -1,0 +1,10 @@
+package fr.insee.lunatic.exception;
+
+/** Thrown when an error occurs during serialization of a questionnaire object. */
+public class SerializationException extends Exception {
+
+    public SerializationException(String message, Exception e) {
+        super(message, e);
+    }
+
+}

--- a/src/test/java/fr/insee/lunatic/test/DataTranslatorsTest.java
+++ b/src/test/java/fr/insee/lunatic/test/DataTranslatorsTest.java
@@ -3,6 +3,7 @@ package fr.insee.lunatic.test;
 import fr.insee.lunatic.Constants;
 import fr.insee.lunatic.conversion.data.JSONLunaticDataToXML;
 import fr.insee.lunatic.conversion.data.XMLLunaticDataToJSON;
+import fr.insee.lunatic.test.utils.XMLDiff;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/fr/insee/lunatic/test/JSONSerializerTest.java
+++ b/src/test/java/fr/insee/lunatic/test/JSONSerializerTest.java
@@ -1,0 +1,42 @@
+package fr.insee.lunatic.test;
+
+import fr.insee.lunatic.conversion.JSONSerializer;
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.test.utils.JsonFormatter;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.JAXBException;
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JSONSerializerTest {
+
+    @Test
+    void serialize_simplestCase() throws JAXBException, UnsupportedEncodingException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId("foo-id");
+        //
+        JSONSerializer serializer = new JSONSerializer();
+        String result = serializer.serialize(questionnaire);
+        //
+        assertEquals("{\"Questionnaire\":{\"id\":\"foo-id\"}}",
+                JsonFormatter.compress(result));
+    }
+
+    @Test
+    void serialize2_simplestCase() throws SerializationException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId("foo-id");
+        //
+        JSONSerializer serializer = new JSONSerializer();
+        String result = serializer.serialize2(questionnaire);
+        //
+        assertEquals("{\"id\":\"foo-id\"}",
+                JsonFormatter.compress(result));
+    }
+
+}

--- a/src/test/java/fr/insee/lunatic/test/LunaticXmlToDataTest.java
+++ b/src/test/java/fr/insee/lunatic/test/LunaticXmlToDataTest.java
@@ -3,6 +3,7 @@ package fr.insee.lunatic.test;
 import fr.insee.lunatic.Constants;
 import fr.insee.lunatic.conversion.data.XMLLunaticDataToJSON;
 import fr.insee.lunatic.conversion.data.XMLLunaticToXMLEmptyData;
+import fr.insee.lunatic.test.utils.XMLDiff;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/fr/insee/lunatic/test/TranslatorsTest.java
+++ b/src/test/java/fr/insee/lunatic/test/TranslatorsTest.java
@@ -5,6 +5,7 @@ import fr.insee.lunatic.conversion.JSONCleaner;
 import fr.insee.lunatic.conversion.XMLLunaticFlatToJSONLunaticFlatTranslator;
 import fr.insee.lunatic.conversion.XMLLunaticToJSONLunaticTranslator;
 import fr.insee.lunatic.conversion.XMLLunaticToXMLLunaticFlatTranslator;
+import fr.insee.lunatic.test.utils.XMLDiff;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/fr/insee/lunatic/test/ValidatorTest.java
+++ b/src/test/java/fr/insee/lunatic/test/ValidatorTest.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.test;
 
+import fr.insee.lunatic.test.utils.XMLDiff;
 import fr.insee.lunatic.utils.Modele;
 import fr.insee.lunatic.utils.SchemaValidator;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/fr/insee/lunatic/test/utils/JsonFormatter.java
+++ b/src/test/java/fr/insee/lunatic/test/utils/JsonFormatter.java
@@ -1,0 +1,18 @@
+package fr.insee.lunatic.test.utils;
+
+/**
+ * Utils class to facilitate json comparison in tests.
+ */
+public class JsonFormatter {
+
+    /**
+     * Compress the json string by removing line breaks and spaces.
+     * Warning: this method also removes spaces inside string content.
+     * @param jsonString Json string.
+     * @return Compressed json string.
+     */
+    public static String compress(String jsonString) {
+        return jsonString.replaceAll("\\s+","").replaceAll("\\n+","");
+    }
+
+}

--- a/src/test/java/fr/insee/lunatic/test/utils/XMLDiff.java
+++ b/src/test/java/fr/insee/lunatic/test/utils/XMLDiff.java
@@ -1,4 +1,4 @@
-package fr.insee.lunatic.test;
+package fr.insee.lunatic.test.utils;
 import java.io.File;
 
 import javax.xml.transform.stream.StreamSource;


### PR DESCRIPTION
## Add secondary sson questionnaire serialization method

We discovered that current json serialization method does not meet Pogues-Back-Office (not only) expectations.

Lunatic json questionnaires that are used by Pogues-Back-Office, Lunatic, Stromae etc. are like this:

```json
{
    "id" : "...",
    ...
}
```

However, `JSONSerialiser` `serialize`'s method return something like this:


```json
{
    "Questionnaire" : {
        "id" : "...",
        ...
    }
}
```

➡️ Added `serialize2` method in the class.
