### PR TITLE
Build/upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.17.0</version>
+			<version>2.20.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
-	<url>http://www.insee.fr</url>
+	<url>https://www.insee.fr</url>
 
 	<properties>
 		<saxon.version>9.7.0-8</saxon.version>
@@ -21,7 +21,7 @@
 	<licenses>
 		<license>
 			<name>MIT License</name>
-			<url>http://www.opensource.org/licenses/mit-license.php</url>
+			<url>https://www.opensource.org/licenses/mit-license.php</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,6 @@
 			<version>${saxon.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<version>2.7.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<version>2.20.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>


### PR DESCRIPTION
- upgrade `log4j-slf4j-impl` (`2.17.0` has vulnerabilities https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl/2.17.0 )
- remove `xalan` dependency that is unused (tests are passing without the lib) and vulnerable (https://mvnrepository.com/artifact/xalan/xalan/2.7.1)
- replace http by https in some urls in the pom

These changes should be non breaking.