### PR TITLE
Fix/resizing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>2.3.2-rc5</version>
+	<version>2.3.2-rc6</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>http://www.insee.fr</url>

--- a/src/main/java/fr/insee/lunatic/conversion/JSONCleaner.java
+++ b/src/main/java/fr/insee/lunatic/conversion/JSONCleaner.java
@@ -23,19 +23,19 @@ public class JSONCleaner {
 	
 	public String clean(String jsonString) throws Exception {
 
-		// New step: apply (Java) symLinks cleaning
-		JSONSymLinksCleaner jsonSymLinksCleaner = new JSONSymLinksCleaner();
-		jsonString = jsonSymLinksCleaner.clean(jsonString);
-
 		if ((jsonString == null) || (jsonString.length() == 0))
 			return null;
 		InputStream json = new ByteArrayInputStream(wrapJsonWithXml(jsonString).getBytes(StandardCharsets.UTF_8));
 
-		return this.generate(json);
+		// Unchanged step: use XSLT "cleaning" sheet
+		String generatedUsingXslt = generate(json);
+
+		// New step: apply (Java) symLinks cleaning
+		JSONSymLinksCleaner jsonSymLinksCleaner = new JSONSymLinksCleaner();
+		return jsonSymLinksCleaner.clean(generatedUsingXslt);
 	}
 	
 	public String generate(InputStream isFinalInput) throws Exception {
-		// Unchanged step: use XSLT "cleaning" sheet
 		OutputStream osOutputFile = generateOS(isFinalInput);
 		String res = osOutputFile.toString();
 		osOutputFile.close();

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -100,11 +100,35 @@
     </xsl:template>
     <!-- 2. When encountering variables node that is not the first, do nothing, the copy to array has already been done at previous step -->    
     <xsl:template match="*[@key='variables' and ancestor::*/@key='resizing' and preceding-sibling::*[@key='variables']]" mode="clean"/>
-    <!-- 3. When encountering value node, do not copy (it is a line return wrongly treated as an object 
+
+    <!-- Copy of the template for "variables" in resizing with "sizeForLinksVariables" for the pairwise component -->
+    <!-- 1.  -->
+    <xsl:template match="*[@key='sizeForLinksVariables' and ancestor::*/@key='resizing'][1]" mode="clean">
+        <fn:array key="sizeForLinksVariables">
+            <xsl:for-each select="../fn:string[@key='sizeForLinksVariables']">
+                <fn:string><xsl:value-of select="text()"/></fn:string>
+            </xsl:for-each>
+        </fn:array>
+    </xsl:template>
+    <!-- 2.  -->
+    <xsl:template match="*[@key='sizeForLinksVariables' and ancestor::*/@key='resizing' and preceding-sibling::*[@key='sizeForLinksVariables']]" mode="clean"/>
+
+    <!-- Same thing for "linksVariables" (pairwise component) -->
+    <!-- 1.  -->
+    <xsl:template match="*[@key='linksVariables' and ancestor::*/@key='resizing'][1]" mode="clean">
+        <fn:array key="linksVariables">
+            <xsl:for-each select="../fn:string[@key='linksVariables']">
+                <fn:string><xsl:value-of select="text()"/></fn:string>
+            </xsl:for-each>
+        </fn:array>
+    </xsl:template>
+    <!-- 2.  -->
+    <xsl:template match="*[@key='linksVariables' and ancestor::*/@key='resizing' and preceding-sibling::*[@key='linksVariables']]" mode="clean"/>
+
+    <!-- When encountering value node, do not copy (it is a line return wrongly treated as an object
     since we do not have a proper schema model for the resizing part...-->
     <xsl:template match="*[@key='value' and ancestor::*/@key='resizing']"  mode="clean"/>
-    
-    
+
     <xsl:template match="@*|node()" mode="clean">
         <xsl:choose>
             <xsl:when test="self::text()">

--- a/src/test/java/fr/insee/lunatic/test/PairwiseTest.java
+++ b/src/test/java/fr/insee/lunatic/test/PairwiseTest.java
@@ -57,27 +57,27 @@ class PairwiseTest {
         //
         URL pairwiseFileUrl = this.getClass().getClassLoader().getResource("pairwise/pairwise-hierarchical-test.xml");
         assert pairwiseFileUrl != null;
-
-        //
-        String xmlFlat = translator.generate(pairwiseFileUrl.openStream());
-        String jsonFlat = translator2.translate(xmlFlat);
-        String result = jsonCleaner.clean(jsonFlat);
-
-        //
-        assertNotNull(result);
         //
         Path pairwisePath = Path.of(pairwiseFileUrl.toURI()).getParent();
         Path outPath = Files.createTempDirectory(pairwisePath, "out");
-        System.out.printf("Writing test pairwise outputs in %s", outPath);
+        System.out.printf("Writing test pairwise outputs in \n%s\n", outPath);
+
+        //
+        String xmlFlat = translator.generate(pairwiseFileUrl.openStream());
         Files.writeString(
                 outPath.resolve("pairwise-flat.xml"),
                 xmlFlat);
+        String jsonFlat = translator2.translate(xmlFlat);
         Files.writeString(
                 outPath.resolve("pairwise-flat.json"),
                 jsonFlat);
+        String result = jsonCleaner.clean(jsonFlat);
         Files.writeString(
                 outPath.resolve("pairwise-cleaned.json"),
                 result);
+
+        //
+        assertNotNull(result);
     }
 
 }

--- a/src/test/java/fr/insee/lunatic/test/TranslatorsTest.java
+++ b/src/test/java/fr/insee/lunatic/test/TranslatorsTest.java
@@ -28,32 +28,31 @@ import java.nio.file.Paths;
 public class TranslatorsTest {
 
 	private XMLDiff xmlDiff = new XMLDiff();
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(TranslatorsTest.class);
-	
+
 	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {
 	}
-	
-	
+
 	@org.junit.jupiter.api.Test
 	public void testQuestionnaireXMLFToJSONF() {
 		logger.debug("Launch test : XMLLunaticFlat -> JSONLunaticFlat");
 		try {
 			String basePath = Constants.RESOURCES_FOLDER_XMLF_2_JSONF_PATH;
-			
+
 			Path outPath = Paths.get(Constants.TEMP_FOLDER_PATH + "/xmlf-2-jsonf-out.json");
 			Files.deleteIfExists(outPath);
 			Path outputFile = Files.createFile(outPath);
-			
+
 			File in = new File(String.format("%s/form_flat.xml", Constants.RESOURCES_FOLDER_DUMMY_PATH));
-			
+
 			XMLLunaticFlatToJSONLunaticFlatTranslator translator = new XMLLunaticFlatToJSONLunaticFlatTranslator();
 			JSONCleaner jsonCleaner = new JSONCleaner();
-			
+
 			String jsonQuestionnaire = jsonCleaner.clean(translator.translate(in));
 			JSONObject jsonOut = new JSONObject(jsonQuestionnaire);
-			
+
 			Files.write(outputFile, jsonQuestionnaire.getBytes("UTF-8"));
 			logger.debug("File generated at : "+outputFile.toString());
 
@@ -78,30 +77,30 @@ public class TranslatorsTest {
 			Assertions.fail();
 		}
 	}
-	
+
 	@Test
 	public void testQuestionnaireXMLHToXMLF() {
 		logger.debug("Launch test : XMLLunatic -> XMLLunaticFlat");
 
 		try {
 			String basePath = Constants.RESOURCES_FOLDER_XMLH_2_XMLF_PATH;
-			
+
 			Path outPath = Paths.get(Constants.TEMP_FOLDER_PATH + "/xmlh-2-xmlf-out.xml");
 			Files.deleteIfExists(outPath);
 			Path outputFile = Files.createFile(outPath);
-			
+
 			File in = new File(String.format("%s/form.xml",  Constants.RESOURCES_FOLDER_DUMMY_PATH));
-			
+
 			XMLLunaticToXMLLunaticFlatTranslator translator = new XMLLunaticToXMLLunaticFlatTranslator();
 
 			String xmlQuestionnaire = translator.generate(in);
 			Files.write(outputFile, xmlQuestionnaire.getBytes("UTF-8"));
 			logger.debug("File generated at : "+outputFile.toString());
-			
+
 			File expectedFile = new File(String.format("%s/out.xml", basePath));
 			Diff diff = xmlDiff.getDiff(outputFile.toFile(),expectedFile);
 			Assertions.assertFalse(diff.hasDifferences(), getDiffMessage(diff, basePath));
-			
+
 		} catch (IOException e) {
 			e.printStackTrace();
 			Assertions.fail();
@@ -114,33 +113,33 @@ public class TranslatorsTest {
 			Assertions.fail();
 		}
 	}
-	
+
 	@Test
 	public void testQuestionnaireXMLHToJSONF() {
 		logger.debug("Launch test : XMLLunatic -> JSONLunaticFlat");
 		try {
-			
+
 			long startTime = System.currentTimeMillis();
-			
+
 			String basePath = Constants.RESOURCES_FOLDER_XMLH_2_JSONF_PATH;
-			
+
 			Path outPath = Paths.get(Constants.TEMP_FOLDER_PATH + "/xmlh-2-jsonf-out.json");
 			Files.deleteIfExists(outPath);
 			Path outputFile = Files.createFile(outPath);
 
 			File in = new File(String.format("%s/form.xml",  Constants.RESOURCES_FOLDER_DUMMY_PATH));
-			
+
 			XMLLunaticToXMLLunaticFlatTranslator translator = new XMLLunaticToXMLLunaticFlatTranslator();
 			XMLLunaticFlatToJSONLunaticFlatTranslator translator2 = new XMLLunaticFlatToJSONLunaticFlatTranslator();
-			JSONCleaner jsonCleaner = new JSONCleaner();			
-			
+			JSONCleaner jsonCleaner = new JSONCleaner();
+
 			String jsonQuestionnaire = jsonCleaner.clean(translator2.translate(translator.generate(in)));
 			JSONObject jsonOut = new JSONObject(jsonQuestionnaire);
 
 			Files.write(outputFile, jsonQuestionnaire.getBytes("UTF-8"));
-			
+
 			long elapsedTime = System.currentTimeMillis() - startTime;
-			
+
 			logger.debug("File generated at : "+outputFile.toString());
 			logger.debug("Transformation time for eno-XML to json lunatic fo JS: " + elapsedTime +" ms");
 
@@ -163,22 +162,22 @@ public class TranslatorsTest {
 			Assertions.fail();
 		}
 	}
-	
+
 	@Test
 	public void testQuestionnaireXMLHToJSONH() {
 		logger.debug("Launch test : XMLLunatic -> JSONLunaticH");
 		try {
 			String basePath = Constants.RESOURCES_FOLDER_XMLH_2_JSONH_PATH;
-			
+
 			Path outPath = Paths.get(Constants.TEMP_FOLDER_PATH + "/xmlh-2-jsonh-out.json");
 			Files.deleteIfExists(outPath);
 			Path outputFile = Files.createFile(outPath);
-			
+
 			File in = new File(String.format("%s/form.xml",  Constants.RESOURCES_FOLDER_DUMMY_PATH));
 
 			XMLLunaticToJSONLunaticTranslator translator = new XMLLunaticToJSONLunaticTranslator();
 			JSONCleaner jsonCleaner = new JSONCleaner();
-			
+
 			String jsonQuestionnaire = jsonCleaner.clean(translator.translate(in));
 			JSONObject jsonOut = new JSONObject(jsonQuestionnaire);
 			Files.write(outputFile, jsonQuestionnaire.getBytes("UTF-8"));
@@ -210,6 +209,5 @@ public class TranslatorsTest {
 		return String.format("Transformed output for %s should match expected XML document:\n %s", path,
 				diff.toString());
 	}
-	
 	
 }

--- a/src/test/resources/pairwise/resizing-issue/lb3ei722-lunatic-expected.json
+++ b/src/test/resources/pairwise/resizing-issue/lb3ei722-lunatic-expected.json
@@ -1,0 +1,649 @@
+
+ { "id" : "lb3ei722",
+  "modele" : "TESTSURSUM",
+  "enoCoreVersion" : "2.4.1",
+  "lunaticModelVersion" : "2.3.1",
+  "generatingDate" : "25-05-2023 14:42:02",
+  "missing" : false,
+  "pagination" : "question",
+  "maxPage" : "10",
+  "label" : 
+  { "value" : "QNONREG - sum, min dans une boucle et sur controle prénom et test filtre occurrence",
+   "type" : "VTL|MD" },
+  "components" : 
+  [ 
+   { "id" : "ksyjs7vy",
+    "componentType" : "Sequence",
+    "page" : "1",
+    "label" : 
+    { "value" : "\"I - \" || \"S0\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyjs7vy",
+      "page" : "1",
+      "label" : 
+      { "value" : "\"I - \" || \"S0\"",
+       "type" : "VTL|MD" } } } },
+   
+   { "id" : "kze792d8",
+    "componentType" : "InputNumber",
+    "mandatory" : false,
+    "page" : "2",
+    "min" : 0,
+    "max" : 10,
+    "decimals" : 0,
+    "label" : 
+    { "value" : "\"➡ \" || \"NB\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "controls" : 
+    [ 
+     { "id" : "kze792d8-format-borne-inf-sup",
+      "typeOfControl" : "FORMAT",
+      "criticality" : "ERROR",
+      "control" : 
+      { "value" : "not(not(isnull(NB)) and (0>NB or 10<NB))",
+       "type" : "VTL" },
+      "errorMessage" : 
+      { "value" : "\" La valeur doit être comprise entre 0 et 10.\"",
+       "type" : "VTL|MD" } },
+     
+     { "id" : "kze792d8-format-decimal",
+      "typeOfControl" : "FORMAT",
+      "criticality" : "ERROR",
+      "control" : 
+      { "value" : "not(not(isnull(NB))  and round(NB,0)<>NB)",
+       "type" : "VTL" },
+      "errorMessage" : 
+      { "value" : "\"Le nombre doit comporter au maximum 0 chiffre(s) après la virgule.\"",
+       "type" : "VTL|MD" } } ],
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyjs7vy",
+      "page" : "1",
+      "label" : 
+      { "value" : "\"I - \" || \"S0\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "NB" ],
+    "response" : 
+    { "name" : "NB" } },
+   
+   { "id" : "ksykfdm9",
+    "componentType" : "Loop",
+    "page" : "3",
+    "depth" : 1,
+    "paginatedLoop" : false,
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyjs7vy",
+      "page" : "1",
+      "label" : 
+      { "value" : "\"I - \" || \"S0\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "NB",
+     "PRENOM" ],
+    "loopDependencies" : 
+    [ "NB" ],
+    "lines" : 
+    { "min" : 
+     { "value" : "cast(NB,integer)",
+      "type" : "VTL" },
+     "max" : 
+     { "value" : "cast(NB,integer)",
+      "type" : "VTL" } },
+    "components" : 
+    [ 
+     { "id" : "ksynhpl3",
+      "componentType" : "Subsequence",
+      "page" : "3",
+      "goToPage" : "3",
+      "label" : 
+      { "value" : "\"Habitants\"",
+       "type" : "VTL|MD" },
+      "conditionFilter" : 
+      { "value" : "true",
+       "type" : "VTL" },
+      "hierarchy" : 
+      { "sequence" : 
+       { "id" : "ksyjs7vy",
+        "page" : "1",
+        "label" : 
+        { "value" : "\"I - \" || \"S0\"",
+         "type" : "VTL|MD" } },
+       "subSequence" : 
+       { "id" : "ksynhpl3",
+        "page" : "3",
+        "label" : 
+        { "value" : "\"Habitants\"",
+         "type" : "VTL|MD" } } },
+      "bindingDependencies" : 
+      [ "NB" ] },
+     
+     { "id" : "ksyjvi40",
+      "componentType" : "Input",
+      "mandatory" : false,
+      "page" : "3",
+      "maxLength" : 249,
+      "label" : 
+      { "value" : "\"➡ \" || \"prénom\"",
+       "type" : "VTL|MD" },
+      "declarations" : 
+      [ 
+       { "id" : "ksyjvi40-l7uj49ok",
+        "declarationType" : "HELP",
+        "position" : "AFTER_QUESTION_TEXT",
+        "label" : 
+        { "value" : "\"Tester Prénom vide et Prénom = A\"",
+         "type" : "VTL|MD" } } ],
+      "conditionFilter" : 
+      { "value" : "true",
+       "type" : "VTL" },
+      "controls" : 
+      [ 
+       { "id" : "ksyjvi40-CI-0",
+        "typeOfControl" : "CONSISTENCY",
+        "criticality" : "WARN",
+        "control" : 
+        { "value" : "not(nvl(PRENOM,\"\")=\"\")",
+         "type" : "VTL" },
+        "errorMessage" : 
+        { "value" : "\"Prenom est vide - controle nvl\"",
+         "type" : "VTL|MD" },
+        "bindingDependencies" : 
+        [ "PRENOM" ] },
+       
+       { "id" : "ksyjvi40-CI-1",
+        "typeOfControl" : "CONSISTENCY",
+        "criticality" : "WARN",
+        "control" : 
+        { "value" : "not(PRENOM = \"A\")",
+         "type" : "VTL" },
+        "errorMessage" : 
+        { "value" : "\"PRénom vaut A\"",
+         "type" : "VTL|MD" },
+        "bindingDependencies" : 
+        [ "PRENOM" ] } ],
+      "hierarchy" : 
+      { "sequence" : 
+       { "id" : "ksyjs7vy",
+        "page" : "1",
+        "label" : 
+        { "value" : "\"I - \" || \"S0\"",
+         "type" : "VTL|MD" } },
+       "subSequence" : 
+       { "id" : "ksynhpl3",
+        "page" : "3",
+        "label" : 
+        { "value" : "\"Habitants\"",
+         "type" : "VTL|MD" } } },
+      "bindingDependencies" : 
+      [ "PRENOM",
+       "NB" ],
+      "response" : 
+      { "name" : "PRENOM" } } ] },
+   
+   { "id" : "ksyniqzx",
+    "componentType" : "Sequence",
+    "page" : "4",
+    "label" : 
+    { "value" : "\"II - \" || \"S1\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyniqzx",
+      "page" : "4",
+      "label" : 
+      { "value" : "\"II - \" || \"S1\"",
+       "type" : "VTL|MD" } } } },
+   
+   { "id" : "ksynkaoo",
+    "componentType" : "Loop",
+    "page" : "5",
+    "maxPage" : "1",
+    "depth" : 1,
+    "paginatedLoop" : true,
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyniqzx",
+      "page" : "4",
+      "label" : 
+      { "value" : "\"II - \" || \"S1\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "AGE",
+     "IND_MAJEUR",
+     "PRENOM" ],
+    "loopDependencies" : 
+    [ "PRENOM" ],
+    "components" : 
+    [ 
+     { "id" : "ksyjxw3a",
+      "componentType" : "Subsequence",
+      "goToPage" : "5.1",
+      "label" : 
+      { "value" : "\"Les ages\"",
+       "type" : "VTL|MD" },
+      "conditionFilter" : 
+      { "value" : "true",
+       "type" : "VTL" },
+      "hierarchy" : 
+      { "sequence" : 
+       { "id" : "ksyniqzx",
+        "page" : "4",
+        "label" : 
+        { "value" : "\"II - \" || \"S1\"",
+         "type" : "VTL|MD" } },
+       "subSequence" : 
+       { "id" : "ksyjxw3a",
+        "page" : "5.1",
+        "label" : 
+        { "value" : "\"Les ages\"",
+         "type" : "VTL|MD" } } },
+      "bindingDependencies" : 
+      [ "PRENOM" ] },
+     
+     { "id" : "ksyke448",
+      "componentType" : "InputNumber",
+      "mandatory" : false,
+      "page" : "5.1",
+      "min" : 0,
+      "max" : 100,
+      "decimals" : 0,
+      "label" : 
+      { "value" : "\"➡ \" || \"Age de l’individu : \" || PRENOM",
+       "type" : "VTL|MD" },
+      "declarations" : 
+      [ 
+       { "id" : "ksyke448-ktwsl4qu",
+        "declarationType" : "HELP",
+        "position" : "AFTER_QUESTION_TEXT",
+        "label" : 
+        { "value" : "\"AGE vaut : \" || cast(AGE,string)",
+         "type" : "VTL|MD" } },
+       
+       { "id" : "ksyke448-l7g2enbf",
+        "declarationType" : "HELP",
+        "position" : "AFTER_QUESTION_TEXT",
+        "label" : 
+        { "value" : "\"IND_MAJEUR :\" || cast(IND_MAJEUR,string)",
+         "type" : "VTL|MD" } } ],
+      "conditionFilter" : 
+      { "value" : "true",
+       "type" : "VTL" },
+      "controls" : 
+      [ 
+       { "id" : "ksyke448-format-borne-inf-sup",
+        "typeOfControl" : "FORMAT",
+        "criticality" : "ERROR",
+        "control" : 
+        { "value" : "not(not(isnull(AGE)) and (0>AGE or 100<AGE))",
+         "type" : "VTL" },
+        "errorMessage" : 
+        { "value" : "\" La valeur doit être comprise entre 0 et 100.\"",
+         "type" : "VTL|MD" } },
+       
+       { "id" : "ksyke448-format-decimal",
+        "typeOfControl" : "FORMAT",
+        "criticality" : "ERROR",
+        "control" : 
+        { "value" : "not(not(isnull(AGE))  and round(AGE,0)<>AGE)",
+         "type" : "VTL" },
+        "errorMessage" : 
+        { "value" : "\"Le nombre doit comporter au maximum 0 chiffre(s) après la virgule.\"",
+         "type" : "VTL|MD" } },
+       
+       { "id" : "ksyke448-CI-0",
+        "typeOfControl" : "CONSISTENCY",
+        "criticality" : "WARN",
+        "control" : 
+        { "value" : "not(isnull(AGE))",
+         "type" : "VTL" },
+        "errorMessage" : 
+        { "value" : "\"Age est vide\"",
+         "type" : "VTL|MD" },
+        "bindingDependencies" : 
+        [ "AGE" ] } ],
+      "hierarchy" : 
+      { "sequence" : 
+       { "id" : "ksyniqzx",
+        "page" : "4",
+        "label" : 
+        { "value" : "\"II - \" || \"S1\"",
+         "type" : "VTL|MD" } },
+       "subSequence" : 
+       { "id" : "ksyjxw3a",
+        "page" : "5.1",
+        "label" : 
+        { "value" : "\"Les ages\"",
+         "type" : "VTL|MD" } } },
+      "bindingDependencies" : 
+      [ "AGE",
+       "IND_MAJEUR",
+       "PRENOM" ],
+      "response" : 
+      { "name" : "AGE" } } ],
+    "iterations" : 
+    { "value" : "count(PRENOM)",
+     "type" : "VTL" } },
+   
+   { "id" : "ku2pnlmr",
+    "componentType" : "Subsequence",
+    "page" : "6",
+    "goToPage" : "6",
+    "label" : 
+    { "value" : "\"Affichage de qq var\"",
+     "type" : "VTL|MD" },
+    "declarations" : 
+    [ 
+     { "id" : "ku2pnlmr-l7t4dzz2",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage du nb de majeurs : \" || cast(SUM_MAJEUR,string)",
+       "type" : "VTL|MD" } },
+     
+     { "id" : "ku2pnlmr-l806u4c8",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage du somme age : \" || cast(SUM_AGE,string)",
+       "type" : "VTL|MD" } },
+     
+     { "id" : "ku2pnlmr-lg6mo14c",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage du min des ages sans cast: \" || cast(MIN_AGE,string)",
+       "type" : "VTL|MD" } } ],
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyniqzx",
+      "page" : "4",
+      "label" : 
+      { "value" : "\"II - \" || \"S1\"",
+       "type" : "VTL|MD" } },
+     "subSequence" : 
+     { "id" : "ku2pnlmr",
+      "page" : "6",
+      "label" : 
+      { "value" : "\"Affichage de qq var\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "SUM_MAJEUR",
+     "SUM_AGE",
+     "MIN_AGE" ] },
+   
+   { "id" : "ku2pxugf",
+    "componentType" : "Input",
+    "mandatory" : false,
+    "page" : "7",
+    "maxLength" : 249,
+    "label" : 
+    { "value" : "\"➡ \" || \"divers\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "(SUM_MAJEUR > 0)",
+     "type" : "VTL",
+     "bindingDependencies" : 
+     [ "SUM_MAJEUR",
+      "IND_MAJEUR",
+      "AGE" ] },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "ksyniqzx",
+      "page" : "4",
+      "label" : 
+      { "value" : "\"II - \" || \"S1\"",
+       "type" : "VTL|MD" } },
+     "subSequence" : 
+     { "id" : "ku2pnlmr",
+      "page" : "6",
+      "label" : 
+      { "value" : "\"Affichage de qq var\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "DIVERS" ],
+    "response" : 
+    { "name" : "DIVERS" } },
+   
+   { "id" : "l7yz0fe5",
+    "componentType" : "Sequence",
+    "page" : "8",
+    "label" : 
+    { "value" : "\"III - \" || \"S3\"",
+     "type" : "VTL|MD" },
+    "declarations" : 
+    [ 
+     { "id" : "l7yz0fe5-l7yyye9y",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage de la somme des ages : \" || cast(SUM_AGE,string)",
+       "type" : "VTL|MD" } },
+     
+     { "id" : "l7yz0fe5-l7yz5mgk",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage du nb de majeurs : \" || cast(SUM_MAJEUR,string)",
+       "type" : "VTL|MD" } },
+     
+     { "id" : "l7yz0fe5-l7yyrp0q",
+      "declarationType" : "HELP",
+      "position" : "AFTER_QUESTION_TEXT",
+      "label" : 
+      { "value" : "\"Affichage du min des ages : \" || cast(MIN_AGE,string)",
+       "type" : "VTL|MD" } } ],
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "l7yz0fe5",
+      "page" : "8",
+      "label" : 
+      { "value" : "\"III - \" || \"S3\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "SUM_AGE",
+     "SUM_MAJEUR",
+     "MIN_AGE" ] },
+   
+   { "id" : "COMMENT-SEQ",
+    "componentType" : "Sequence",
+    "page" : "9",
+    "label" : 
+    { "value" : "\"Commentaire\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "COMMENT-SEQ",
+      "page" : "9",
+      "label" : 
+      { "value" : "\"Commentaire\"",
+       "type" : "VTL|MD" } } } },
+   
+   { "id" : "COMMENT-QUESTION",
+    "componentType" : "Textarea",
+    "mandatory" : false,
+    "page" : "10",
+    "maxLength" : 2000,
+    "label" : 
+    { "value" : "\"Avez-vous des remarques concernant l'enquête ou des commentaires ?\"",
+     "type" : "VTL|MD" },
+    "conditionFilter" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "hierarchy" : 
+    { "sequence" : 
+     { "id" : "COMMENT-SEQ",
+      "page" : "9",
+      "label" : 
+      { "value" : "\"Commentaire\"",
+       "type" : "VTL|MD" } } },
+    "bindingDependencies" : 
+    [ "COMMENT_QE" ],
+    "response" : 
+    { "name" : "COMMENT_QE" } } ],
+  "variables" : 
+  [ 
+   { "variableType" : "COLLECTED",
+    "name" : "COMMENT_QE",
+    "values" : 
+    { "PREVIOUS" : null,
+     "COLLECTED" : null,
+     "FORCED" : null,
+     "EDITED" : null,
+     "INPUTED" : null } },
+   
+   { "variableType" : "COLLECTED",
+    "name" : "NB",
+    "values" : 
+    { "PREVIOUS" : null,
+     "COLLECTED" : null,
+     "FORCED" : null,
+     "EDITED" : null,
+     "INPUTED" : null } },
+   
+   { "variableType" : "COLLECTED",
+    "name" : "PRENOM",
+    "values" : 
+    { "PREVIOUS" : 
+     [ null ],
+     "COLLECTED" : 
+     [ null ],
+     "FORCED" : 
+     [ null ],
+     "EDITED" : 
+     [ null ],
+     "INPUTED" : 
+     [ null ] } },
+   
+   { "variableType" : "COLLECTED",
+    "name" : "AGE",
+    "values" : 
+    { "PREVIOUS" : 
+     [ null ],
+     "COLLECTED" : 
+     [ null ],
+     "FORCED" : 
+     [ null ],
+     "EDITED" : 
+     [ null ],
+     "INPUTED" : 
+     [ null ] } },
+   
+   { "variableType" : "COLLECTED",
+    "name" : "DIVERS",
+    "values" : 
+    { "PREVIOUS" : null,
+     "COLLECTED" : null,
+     "FORCED" : null,
+     "EDITED" : null,
+     "INPUTED" : null } },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "FILTER_RESULT_NB",
+    "expression" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "inFilter" : "false" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "FILTER_RESULT_PRENOM",
+    "expression" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "shapeFrom" : "PRENOM",
+    "inFilter" : "false" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "IND_MAJEUR",
+    "expression" : 
+    { "value" : "if nvl(AGE,0) > 17 then 1 else 0",
+     "type" : "VTL" },
+    "bindingDependencies" : 
+    [ "AGE" ],
+    "shapeFrom" : "PRENOM",
+    "inFilter" : "true" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "FILTER_RESULT_AGE",
+    "expression" : 
+    { "value" : "true",
+     "type" : "VTL" },
+    "shapeFrom" : "AGE",
+    "inFilter" : "false" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "FILTER_RESULT_DIVERS",
+    "expression" : 
+    { "value" : "(SUM_MAJEUR > 0)",
+     "type" : "VTL" },
+    "bindingDependencies" : 
+    [ "SUM_MAJEUR" ],
+    "inFilter" : "false" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "SUM_MAJEUR",
+    "expression" : 
+    { "value" : "sum(IND_MAJEUR)",
+     "type" : "VTL" },
+    "bindingDependencies" : 
+    [ "IND_MAJEUR",
+     "AGE" ],
+    "inFilter" : "true" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "SUM_AGE",
+    "expression" : 
+    { "value" : "sum(AGE)",
+     "type" : "VTL" },
+    "bindingDependencies" : 
+    [ "AGE" ],
+    "inFilter" : "false" },
+   
+   { "variableType" : "CALCULATED",
+    "name" : "MIN_AGE",
+    "expression" : 
+    { "value" : "min(AGE)",
+     "type" : "VTL" },
+    "bindingDependencies" : 
+    [ "AGE" ],
+    "inFilter" : "false" } ],
+  "cleaning" : 
+  { "SUM_MAJEUR" : 
+   { "DIVERS" : "(SUM_MAJEUR > 0)" },
+   "IND_MAJEUR" : 
+   { "DIVERS" : "(SUM_MAJEUR > 0)" },
+   "AGE" : 
+   { "DIVERS" : "(SUM_MAJEUR > 0)" } },
+  "resizing" : 
+  { "NB" : 
+   { "size" : "cast(NB,integer)",
+    "variables" : 
+    [ "PRENOM",
+     "AGE" ] } } }

--- a/src/test/resources/pairwise/resizing-issue/lb3ei722-lunatic-hierarchical.xml
+++ b/src/test/resources/pairwise/resizing-issue/lb3ei722-lunatic-hierarchical.xml
@@ -1,0 +1,717 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Questionnaire xmlns="http://xml.insee.fr/schema/applis/lunatic-h"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                id="lb3ei722"
+                modele="TESTSURSUM"
+                enoCoreVersion="2.4.1"
+                missing="false"
+                pagination="question"
+                maxPage="10">
+   <label>
+      <value>QNONREG - sum, min dans une boucle et sur controle prénom et test filtre occurrence</value>
+      <type>VTL|MD</type>
+   </label>
+   <components xsi:type="Sequence"
+                componentType="Sequence"
+                id="ksyjs7vy"
+                page="1">
+      <label>
+         <value>"I - " || "S0"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="ksyjs7vy" page="1">
+            <label>
+               <value>"I - " || "S0"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <components xsi:type="InputNumber"
+                   componentType="InputNumber"
+                   id="kze792d8"
+                   mandatory="false"
+                   min="0"
+                   max="10"
+                   decimals="0"
+                   page="2">
+         <label>
+            <value>"➡ " || "NB"</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <controls id="kze792d8-format-borne-inf-sup"
+                    criticality="ERROR"
+                    typeOfControl="FORMAT">
+            <control>
+               <value>not(not(isnull(NB)) and (0&gt;NB or 10&lt;NB))</value>
+               <type>VTL</type>
+            </control>
+            <errorMessage>
+               <value>" La valeur doit être comprise entre 0 et 10."</value>
+               <type>VTL|MD</type>
+            </errorMessage>
+         </controls>
+         <controls id="kze792d8-format-decimal"
+                    criticality="ERROR"
+                    typeOfControl="FORMAT">
+            <control>
+               <value>not(not(isnull(NB))  and round(NB,0)&lt;&gt;NB)</value>
+               <type>VTL</type>
+            </control>
+            <errorMessage>
+               <value>"Le nombre doit comporter au maximum 0 chiffre(s) après la virgule."</value>
+               <type>VTL|MD</type>
+            </errorMessage>
+         </controls>
+         <hierarchy>
+            <sequence id="ksyjs7vy" page="1">
+               <label>
+                  <value>"I - " || "S0"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>NB</bindingDependencies>
+         <response name="NB"/>
+      </components>
+      <components xsi:type="Loop"
+                   componentType="Loop"
+                   id="ksykfdm9"
+                   depth="1"
+                   page="3"
+                   paginatedLoop="false">
+         <lines>
+            <min>
+               <value>cast(NB,integer)</value>
+               <type>VTL</type>
+            </min>
+            <max>
+               <value>cast(NB,integer)</value>
+               <type>VTL</type>
+            </max>
+         </lines>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="ksyjs7vy" page="1">
+               <label>
+                  <value>"I - " || "S0"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>NB</bindingDependencies>
+         <bindingDependencies>PRENOM</bindingDependencies>
+         <loopDependencies>NB</loopDependencies>
+         <components xsi:type="Subsequence"
+                      componentType="Subsequence"
+                      id="ksynhpl3"
+                      page="3"
+                      goToPage="3">
+            <label>
+               <value>"Habitants"</value>
+               <type>VTL|MD</type>
+            </label>
+            <conditionFilter>
+               <value>true</value>
+               <type>VTL</type>
+            </conditionFilter>
+            <hierarchy>
+               <sequence id="ksyjs7vy" page="1">
+                  <label>
+                     <value>"I - " || "S0"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </sequence>
+               <subSequence id="ksynhpl3" page="3">
+                  <label>
+                     <value>"Habitants"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </subSequence>
+            </hierarchy>
+            <bindingDependencies>NB</bindingDependencies>
+            <components xsi:type="Input"
+                         componentType="Input"
+                         id="ksyjvi40"
+                         maxLength="249"
+                         mandatory="false"
+                         page="3">
+               <label>
+                  <value>"➡ " || "prénom"</value>
+                  <type>VTL|MD</type>
+               </label>
+               <declarations declarationType="HELP"
+                              id="ksyjvi40-l7uj49ok"
+                              position="AFTER_QUESTION_TEXT">
+                  <label>
+                     <value>"Tester Prénom vide et Prénom = A"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </declarations>
+               <conditionFilter>
+                  <value>true</value>
+                  <type>VTL</type>
+               </conditionFilter>
+               <controls id="ksyjvi40-CI-0" criticality="WARN" typeOfControl="CONSISTENCY">
+                  <control>
+                     <value>not(nvl(PRENOM,"")="")</value>
+                     <type>VTL</type>
+                  </control>
+                  <errorMessage>
+                     <value>"Prenom est vide - controle nvl"</value>
+                     <type>VTL|MD</type>
+                  </errorMessage>
+                  <bindingDependencies>PRENOM</bindingDependencies>
+               </controls>
+               <controls id="ksyjvi40-CI-1" criticality="WARN" typeOfControl="CONSISTENCY">
+                  <control>
+                     <value>not(PRENOM = "A")</value>
+                     <type>VTL</type>
+                  </control>
+                  <errorMessage>
+                     <value>"PRénom vaut A"</value>
+                     <type>VTL|MD</type>
+                  </errorMessage>
+                  <bindingDependencies>PRENOM</bindingDependencies>
+               </controls>
+               <hierarchy>
+                  <sequence id="ksyjs7vy" page="1">
+                     <label>
+                        <value>"I - " || "S0"</value>
+                        <type>VTL|MD</type>
+                     </label>
+                  </sequence>
+                  <subSequence id="ksynhpl3" page="3">
+                     <label>
+                        <value>"Habitants"</value>
+                        <type>VTL|MD</type>
+                     </label>
+                  </subSequence>
+               </hierarchy>
+               <bindingDependencies>PRENOM</bindingDependencies>
+               <bindingDependencies>NB</bindingDependencies>
+               <response name="PRENOM"/>
+            </components>
+         </components>
+      </components>
+   </components>
+   <components xsi:type="Sequence"
+                componentType="Sequence"
+                id="ksyniqzx"
+                page="4">
+      <label>
+         <value>"II - " || "S1"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="ksyniqzx" page="4">
+            <label>
+               <value>"II - " || "S1"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <components xsi:type="Loop"
+                   componentType="Loop"
+                   id="ksynkaoo"
+                   depth="1"
+                   page="5"
+                   maxPage="1"
+                   paginatedLoop="true">
+         <iterations>
+            <value>count(PRENOM)</value>
+            <type>VTL</type>
+         </iterations>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="ksyniqzx" page="4">
+               <label>
+                  <value>"II - " || "S1"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>AGE</bindingDependencies>
+         <bindingDependencies>IND_MAJEUR</bindingDependencies>
+         <bindingDependencies>PRENOM</bindingDependencies>
+         <loopDependencies>PRENOM</loopDependencies>
+         <components xsi:type="Subsequence"
+                      componentType="Subsequence"
+                      id="ksyjxw3a"
+                      goToPage="5.1">
+            <label>
+               <value>"Les ages"</value>
+               <type>VTL|MD</type>
+            </label>
+            <conditionFilter>
+               <value>true</value>
+               <type>VTL</type>
+            </conditionFilter>
+            <hierarchy>
+               <sequence id="ksyniqzx" page="4">
+                  <label>
+                     <value>"II - " || "S1"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </sequence>
+               <subSequence id="ksyjxw3a" page="5.1">
+                  <label>
+                     <value>"Les ages"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </subSequence>
+            </hierarchy>
+            <bindingDependencies>PRENOM</bindingDependencies>
+            <components xsi:type="InputNumber"
+                         componentType="InputNumber"
+                         id="ksyke448"
+                         mandatory="false"
+                         min="0"
+                         max="100"
+                         decimals="0"
+                         page="5.1">
+               <label>
+                  <value>"➡ " || "Age de l’individu : " || PRENOM</value>
+                  <type>VTL|MD</type>
+               </label>
+               <declarations declarationType="HELP"
+                              id="ksyke448-ktwsl4qu"
+                              position="AFTER_QUESTION_TEXT">
+                  <label>
+                     <value>"AGE vaut : " || cast(AGE,string)</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </declarations>
+               <declarations declarationType="HELP"
+                              id="ksyke448-l7g2enbf"
+                              position="AFTER_QUESTION_TEXT">
+                  <label>
+                     <value>"IND_MAJEUR :" || cast(IND_MAJEUR,string)</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </declarations>
+               <conditionFilter>
+                  <value>true</value>
+                  <type>VTL</type>
+               </conditionFilter>
+               <controls id="ksyke448-format-borne-inf-sup"
+                          criticality="ERROR"
+                          typeOfControl="FORMAT">
+                  <control>
+                     <value>not(not(isnull(AGE)) and (0&gt;AGE or 100&lt;AGE))</value>
+                     <type>VTL</type>
+                  </control>
+                  <errorMessage>
+                     <value>" La valeur doit être comprise entre 0 et 100."</value>
+                     <type>VTL|MD</type>
+                  </errorMessage>
+               </controls>
+               <controls id="ksyke448-format-decimal"
+                          criticality="ERROR"
+                          typeOfControl="FORMAT">
+                  <control>
+                     <value>not(not(isnull(AGE))  and round(AGE,0)&lt;&gt;AGE)</value>
+                     <type>VTL</type>
+                  </control>
+                  <errorMessage>
+                     <value>"Le nombre doit comporter au maximum 0 chiffre(s) après la virgule."</value>
+                     <type>VTL|MD</type>
+                  </errorMessage>
+               </controls>
+               <controls id="ksyke448-CI-0" criticality="WARN" typeOfControl="CONSISTENCY">
+                  <control>
+                     <value>not(isnull(AGE))</value>
+                     <type>VTL</type>
+                  </control>
+                  <errorMessage>
+                     <value>"Age est vide"</value>
+                     <type>VTL|MD</type>
+                  </errorMessage>
+                  <bindingDependencies>AGE</bindingDependencies>
+               </controls>
+               <hierarchy>
+                  <sequence id="ksyniqzx" page="4">
+                     <label>
+                        <value>"II - " || "S1"</value>
+                        <type>VTL|MD</type>
+                     </label>
+                  </sequence>
+                  <subSequence id="ksyjxw3a" page="5.1">
+                     <label>
+                        <value>"Les ages"</value>
+                        <type>VTL|MD</type>
+                     </label>
+                  </subSequence>
+               </hierarchy>
+               <bindingDependencies>AGE</bindingDependencies>
+               <bindingDependencies>IND_MAJEUR</bindingDependencies>
+               <bindingDependencies>PRENOM</bindingDependencies>
+               <response name="AGE"/>
+            </components>
+         </components>
+      </components>
+      <components xsi:type="Subsequence"
+                   componentType="Subsequence"
+                   id="ku2pnlmr"
+                   page="6"
+                   goToPage="6">
+         <label>
+            <value>"Affichage de qq var"</value>
+            <type>VTL|MD</type>
+         </label>
+         <declarations declarationType="HELP"
+                        id="ku2pnlmr-l7t4dzz2"
+                        position="AFTER_QUESTION_TEXT">
+            <label>
+               <value>"Affichage du nb de majeurs : " || cast(SUM_MAJEUR,string)</value>
+               <type>VTL|MD</type>
+            </label>
+         </declarations>
+         <declarations declarationType="HELP"
+                        id="ku2pnlmr-l806u4c8"
+                        position="AFTER_QUESTION_TEXT">
+            <label>
+               <value>"Affichage du somme age : " || cast(SUM_AGE,string)</value>
+               <type>VTL|MD</type>
+            </label>
+         </declarations>
+         <declarations declarationType="HELP"
+                        id="ku2pnlmr-lg6mo14c"
+                        position="AFTER_QUESTION_TEXT">
+            <label>
+               <value>"Affichage du min des ages sans cast: " || cast(MIN_AGE,string)</value>
+               <type>VTL|MD</type>
+            </label>
+         </declarations>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="ksyniqzx" page="4">
+               <label>
+                  <value>"II - " || "S1"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+            <subSequence id="ku2pnlmr" page="6">
+               <label>
+                  <value>"Affichage de qq var"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </subSequence>
+         </hierarchy>
+         <bindingDependencies>SUM_MAJEUR</bindingDependencies>
+         <bindingDependencies>SUM_AGE</bindingDependencies>
+         <bindingDependencies>MIN_AGE</bindingDependencies>
+         <components xsi:type="Input"
+                      componentType="Input"
+                      id="ku2pxugf"
+                      maxLength="249"
+                      mandatory="false"
+                      page="7">
+            <label>
+               <value>"➡ " || "divers"</value>
+               <type>VTL|MD</type>
+            </label>
+            <conditionFilter>
+               <value>(SUM_MAJEUR &gt; 0)</value>
+               <type>VTL</type>
+               <bindingDependencies>SUM_MAJEUR</bindingDependencies>
+               <bindingDependencies>IND_MAJEUR</bindingDependencies>
+               <bindingDependencies>AGE</bindingDependencies>
+            </conditionFilter>
+            <hierarchy>
+               <sequence id="ksyniqzx" page="4">
+                  <label>
+                     <value>"II - " || "S1"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </sequence>
+               <subSequence id="ku2pnlmr" page="6">
+                  <label>
+                     <value>"Affichage de qq var"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </subSequence>
+            </hierarchy>
+            <bindingDependencies>DIVERS</bindingDependencies>
+            <response name="DIVERS"/>
+         </components>
+      </components>
+   </components>
+   <components xsi:type="Sequence"
+                componentType="Sequence"
+                id="l7yz0fe5"
+                page="8">
+      <label>
+         <value>"III - " || "S3"</value>
+         <type>VTL|MD</type>
+      </label>
+      <declarations declarationType="HELP"
+                     id="l7yz0fe5-l7yyye9y"
+                     position="AFTER_QUESTION_TEXT">
+         <label>
+            <value>"Affichage de la somme des ages : " || cast(SUM_AGE,string)</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <declarations declarationType="HELP"
+                     id="l7yz0fe5-l7yz5mgk"
+                     position="AFTER_QUESTION_TEXT">
+         <label>
+            <value>"Affichage du nb de majeurs : " || cast(SUM_MAJEUR,string)</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <declarations declarationType="HELP"
+                     id="l7yz0fe5-l7yyrp0q"
+                     position="AFTER_QUESTION_TEXT">
+         <label>
+            <value>"Affichage du min des ages : " || cast(MIN_AGE,string)</value>
+            <type>VTL|MD</type>
+         </label>
+      </declarations>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="l7yz0fe5" page="8">
+            <label>
+               <value>"III - " || "S3"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <bindingDependencies>SUM_AGE</bindingDependencies>
+      <bindingDependencies>SUM_MAJEUR</bindingDependencies>
+      <bindingDependencies>MIN_AGE</bindingDependencies>
+   </components>
+   <components xsi:type="Sequence"
+                componentType="Sequence"
+                id="COMMENT-SEQ"
+                page="9">
+      <label>
+         <value>"Commentaire"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="COMMENT-SEQ" page="9">
+            <label>
+               <value>"Commentaire"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <components xsi:type="Textarea"
+                   componentType="Textarea"
+                   id="COMMENT-QUESTION"
+                   maxLength="2000"
+                   mandatory="false"
+                   page="10">
+         <label>
+            <value>"Avez-vous des remarques concernant l'enquête ou des commentaires ?"</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="COMMENT-SEQ" page="9">
+               <label>
+                  <value>"Commentaire"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>COMMENT_QE</bindingDependencies>
+         <response name="COMMENT_QE"/>
+      </components>
+   </components>
+   <variables variableType="COLLECTED" xsi:type="VariableType">
+      <name>COMMENT_QE</name>
+      <!--<componentRef>COMMENT-QUESTION</componentRef>-->
+      <values>
+         <PREVIOUS xsi:nil="true"/>
+         <COLLECTED xsi:nil="true"/>
+         <FORCED xsi:nil="true"/>
+         <EDITED xsi:nil="true"/>
+         <INPUTED xsi:nil="true"/>
+      </values>
+   </variables>
+   <variables variableType="COLLECTED" xsi:type="VariableType">
+      <name>NB</name>
+      <values>
+         <PREVIOUS xsi:nil="true"/>
+         <COLLECTED xsi:nil="true"/>
+         <FORCED xsi:nil="true"/>
+         <EDITED xsi:nil="true"/>
+         <INPUTED xsi:nil="true"/>
+      </values>
+   </variables>
+   <variables variableType="COLLECTED" xsi:type="VariableTypeArray">
+      <name>PRENOM</name>
+      <values>
+         <PREVIOUS xsi:type="PREVIOUSArray">
+            <PREVIOUS xsi:nil="true"/>
+         </PREVIOUS>
+         <COLLECTED xsi:type="COLLECTEDArray">
+            <COLLECTED xsi:nil="true"/>
+         </COLLECTED>
+         <FORCED xsi:type="FORCEDArray">
+            <FORCED xsi:nil="true"/>
+         </FORCED>
+         <EDITED xsi:type="EDITEDArray">
+            <EDITED xsi:nil="true"/>
+         </EDITED>
+         <INPUTED xsi:type="INPUTEDArray">
+            <INPUTED xsi:nil="true"/>
+         </INPUTED>
+      </values>
+   </variables>
+   <variables variableType="COLLECTED" xsi:type="VariableTypeArray">
+      <name>AGE</name>
+      <values>
+         <PREVIOUS xsi:type="PREVIOUSArray">
+            <PREVIOUS xsi:nil="true"/>
+         </PREVIOUS>
+         <COLLECTED xsi:type="COLLECTEDArray">
+            <COLLECTED xsi:nil="true"/>
+         </COLLECTED>
+         <FORCED xsi:type="FORCEDArray">
+            <FORCED xsi:nil="true"/>
+         </FORCED>
+         <EDITED xsi:type="EDITEDArray">
+            <EDITED xsi:nil="true"/>
+         </EDITED>
+         <INPUTED xsi:type="INPUTEDArray">
+            <INPUTED xsi:nil="true"/>
+         </INPUTED>
+      </values>
+   </variables>
+   <variables variableType="COLLECTED" xsi:type="VariableType">
+      <name>DIVERS</name>
+      <values>
+         <PREVIOUS xsi:nil="true"/>
+         <COLLECTED xsi:nil="true"/>
+         <FORCED xsi:nil="true"/>
+         <EDITED xsi:nil="true"/>
+         <INPUTED xsi:nil="true"/>
+      </values>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>FILTER_RESULT_NB</name>
+      <expression>
+         <value>true</value>
+         <type>VTL</type>
+      </expression>
+      <inFilter>false</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>FILTER_RESULT_PRENOM</name>
+      <expression>
+         <value>true</value>
+         <type>VTL</type>
+      </expression>
+      <shapeFrom>PRENOM</shapeFrom>
+      <inFilter>false</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>IND_MAJEUR</name>
+      <expression>
+         <value>if nvl(AGE,0) &gt; 17 then 1 else 0</value>
+         <type>VTL</type>
+      </expression>
+      <bindingDependencies>AGE</bindingDependencies>
+      <shapeFrom>PRENOM</shapeFrom>
+      <inFilter>true</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>FILTER_RESULT_AGE</name>
+      <expression>
+         <value>true</value>
+         <type>VTL</type>
+      </expression>
+      <shapeFrom>AGE</shapeFrom>
+      <inFilter>false</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>FILTER_RESULT_DIVERS</name>
+      <expression>
+         <value>(SUM_MAJEUR &gt; 0)</value>
+         <type>VTL</type>
+      </expression>
+      <bindingDependencies>SUM_MAJEUR</bindingDependencies>
+      <inFilter>false</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>SUM_MAJEUR</name>
+      <expression>
+         <value>sum(IND_MAJEUR)</value>
+         <type>VTL</type>
+      </expression>
+      <bindingDependencies>IND_MAJEUR</bindingDependencies>
+      <bindingDependencies>AGE</bindingDependencies>
+      <inFilter>true</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>SUM_AGE</name>
+      <expression>
+         <value>sum(AGE)</value>
+         <type>VTL</type>
+      </expression>
+      <bindingDependencies>AGE</bindingDependencies>
+      <inFilter>false</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+      <name>MIN_AGE</name>
+      <expression>
+         <value>min(AGE)</value>
+         <type>VTL</type>
+      </expression>
+      <bindingDependencies>AGE</bindingDependencies>
+      <inFilter>false</inFilter>
+   </variables>
+   <cleaning>
+      <SUM_MAJEUR>
+         <DIVERS>(SUM_MAJEUR &gt; 0)</DIVERS>
+      </SUM_MAJEUR>
+      <IND_MAJEUR>
+         <DIVERS>(SUM_MAJEUR &gt; 0)</DIVERS>
+      </IND_MAJEUR>
+      <AGE>
+         <DIVERS>(SUM_MAJEUR &gt; 0)</DIVERS>
+      </AGE>
+   </cleaning>
+   <resizing>
+      <NB>
+         <size>cast(NB,integer)</size>
+         <variables>PRENOM</variables>
+         <variables>AGE</variables>
+      </NB>
+   </resizing>
+</Questionnaire>


### PR DESCRIPTION
The introduction of the "sym links cleaning" step in the `JSONCleaner` class introduced a regression in the `"resizing"` part of json questionnaires.

The reason: the sym links cleaning parses the json content, yet the "non-cleaned" json after xml flat to json flat translation contains duplicate keys (which is illegal in json, so some values were lost).

Doing the sym links cleaning _after_ the other cleaning method solved the problem.

YET, doing so revealed a latent problem in the `json-cleaner.xsl` : the sheet didn't support `"sizeForLinksVariables"` and `"linksVariables"` properties, introduced in the `"resizing"` part for the pairwise component.

**Note: These changes the indentation of json questionnaires.**
