### PR TITLE
refactor: use proper enum in BodyCell componentType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.0.4-SNAPSHOT</version>
+	<version>3.0.5-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
@@ -39,7 +39,7 @@ public class BodyCell {
     protected ResponseType response;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected List<String> bindingDependencies;
-    protected String componentType;
+    protected ComponentTypeEnum componentType;
     protected BigInteger maxLength;
     protected Double min;
     protected Double max;


### PR DESCRIPTION
Use `ComponentTypeEnum` instead of `String` for the "componentType" property in "BodyCell" class.

Only changes Java classes, no impact on the serialization of valid questionnaires.

(NB: we should find a way to make something cleaner than "BodyCell" (make polymorphism by re-using proper objects like LabelType or ComponentType) later on.)