### PR TITLE
build: use correct logging binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
 			<version>2.20.0</version>
 		</dependency>
 


### PR DESCRIPTION
Logj binding dependency changed after slf4j 2.+