### PR TITLE
Feat/two dimensions variable array

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.1.2-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.1-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>
@@ -63,6 +63,7 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
 			<version>2.20.0</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/fr/insee/lunatic/model/flat/ValueTypeTwoDimensionsArray.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ValueTypeTwoDimensionsArray.java
@@ -1,0 +1,22 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonPropertyOrder({
+        "value"
+})
+@Getter
+@Setter
+public class ValueTypeTwoDimensionsArray {
+
+    protected List<List<String>> value;
+
+    public ValueTypeTwoDimensionsArray() {
+        this.value = new ArrayList<>(new ArrayList<>());
+    }
+}

--- a/src/main/java/fr/insee/lunatic/model/flat/ValuesTypeTwoDimensionsArray.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ValuesTypeTwoDimensionsArray.java
@@ -1,0 +1,50 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonPropertyOrder({
+        "previous",
+        "collected",
+        "forced",
+        "edited",
+        "inputed"
+})
+@Getter
+@Setter
+public class ValuesTypeTwoDimensionsArray {
+
+    /* Note: for now, seems that nested loops (or loop of loop) will be forbidden.
+    * This modeling only works for "simple" loops. */
+
+    @JsonProperty(value = "PREVIOUS")
+    protected List<List<String>> previous;
+    @JsonProperty(value = "COLLECTED")
+    protected List<List<String>> collected;
+    @JsonProperty(value = "FORCED")
+    protected List<List<String>> forced;
+    @JsonProperty(value = "EDITED")
+    protected List<List<String>> edited;
+    @JsonProperty(value = "INPUTED")
+    protected List<List<String>> inputed;
+    
+    public ValuesTypeTwoDimensionsArray() {
+        previous = newBidimentionalList();
+        collected = newBidimentionalList();
+        forced = newBidimentionalList();
+        edited = newBidimentionalList();
+        inputed = newBidimentionalList();
+    }
+    
+    private List<List<String>> newBidimentionalList() {
+        List<List<String>> list = new ArrayList<>();
+        list.add(new ArrayList<>());
+        return list;
+    }
+
+}

--- a/src/main/java/fr/insee/lunatic/model/flat/VariableTypeTwoDimensionsArray.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/VariableTypeTwoDimensionsArray.java
@@ -1,0 +1,21 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+@JsonPropertyOrder({
+        "value",
+        "values"
+})
+@Getter
+@Setter
+public class VariableTypeTwoDimensionsArray extends IVariableType {
+
+    /** Value field for external variables */
+    protected ValueTypeTwoDimensionsArray value;
+
+    /** Values field for collected variables */
+    protected ValuesTypeTwoDimensionsArray values;
+
+}

--- a/src/test/java/fr/insee/lunatic/conversion/VariableValuesSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/VariableValuesSerializationTest.java
@@ -75,4 +75,37 @@ class VariableValuesSerializationTest {
         JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
     }
 
+    @Test
+    void serializeVariableTwoDimensionsArrayWithEmptyValues() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        //
+        VariableTypeTwoDimensionsArray loopVariable = new VariableTypeTwoDimensionsArray();
+        loopVariable.setName("PAIRWISE_VAR");
+        loopVariable.setVariableType(VariableTypeEnum.COLLECTED);
+        loopVariable.setValues(new ValuesTypeTwoDimensionsArray());
+        questionnaire.getVariables().add(loopVariable);
+        //
+        JsonSerializer jsonSerializer = new JsonSerializer();
+        String result = jsonSerializer.serialize(questionnaire);
+        //
+        String expectedJson = """
+                {
+                  "variables": [
+                    {
+                      "variableType": "COLLECTED",
+                      "name": "PAIRWISE_VAR",
+                      "values": {
+                        "PREVIOUS": [[]],
+                        "COLLECTED": [[]],
+                        "FORCED": [[]],
+                        "EDITED": [[]],
+                        "INPUTED": [[]]
+                      }
+                    }
+                  ]
+                }""";
+        JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+    }
+
 }


### PR DESCRIPTION
Create objects for two-dimensions variables.

Such variable is only used in the pairwise component for now.

Since we've agreed that we won't support "loops of loops" / "nested loops", the implementation is not designed to support an undefined level of dimensions for variable values: 

- `VariableType` for "simple" variables
- `VariableTypeArray` for "one-dimension" variables (such as variable that belong to a loop)
- `VariableTypeTwoDimensionsArray` for "tow-dimensions" variables (such as the pairwise variable)

(three or more dimensions are not allowed).