### PR TITLE
fix: suggester synonyms serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.2.2-SNAPSHOT</version>
+	<version>3.2.3-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
@@ -1,0 +1,36 @@
+package fr.insee.lunatic.conversion;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import fr.insee.lunatic.model.flat.FieldSynonym;
+import fr.insee.lunatic.model.flat.FieldSynonyms;
+
+import java.io.IOException;
+
+public class FieldSynonymsSerializer extends StdSerializer<FieldSynonyms> {
+
+    @SuppressWarnings("unused") // default constructor is required by jackson
+    public FieldSynonymsSerializer() {
+        this(null);
+    }
+
+    public FieldSynonymsSerializer(Class<FieldSynonyms> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(FieldSynonyms fieldSynonyms, JsonGenerator jsonGenerator, SerializerProvider provider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+        for(FieldSynonym fieldSynonym : fieldSynonyms) {
+            jsonGenerator.writeArrayFieldStart(fieldSynonym.getSource());
+            for (String synonymString : fieldSynonym.getTarget()) {
+                jsonGenerator.writeString(synonymString);
+            }
+            jsonGenerator.writeEndArray();
+        }
+        jsonGenerator.writeEndObject();
+    }
+
+}

--- a/src/main/java/fr/insee/lunatic/conversion/SymLinksSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/SymLinksSerializer.java
@@ -7,7 +7,7 @@ import fr.insee.lunatic.model.flat.SymLinksType;
 
 import java.io.IOException;
 
-public class SymLinksSerializer  extends StdSerializer<SymLinksType> {
+public class SymLinksSerializer extends StdSerializer<SymLinksType> {
 
     public SymLinksSerializer() {
         this(null);
@@ -19,15 +19,15 @@ public class SymLinksSerializer  extends StdSerializer<SymLinksType> {
 
     @Override
     public void serialize(
-            SymLinksType symLinksType, JsonGenerator jgen, SerializerProvider provider)
+            SymLinksType symLinksType, JsonGenerator jsonGenerator, SerializerProvider provider)
             throws IOException {
-
-        jgen.writeStartObject();
-            jgen.writeObjectFieldStart(symLinksType.getName());
-            for(SymLinksType.LINK link : symLinksType.getLink()) {
-                jgen.writeStringField(link.getSource(), link.getTarget());
-            }
-            jgen.writeEndObject();
-        jgen.writeEndObject();
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeObjectFieldStart(symLinksType.getName());
+        for(SymLinksType.LINK link : symLinksType.getLink()) {
+            jsonGenerator.writeStringField(link.getSource(), link.getTarget());
+        }
+        jsonGenerator.writeEndObject();
+        jsonGenerator.writeEndObject();
     }
+
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/FieldSynonyms.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/FieldSynonyms.java
@@ -1,0 +1,9 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import fr.insee.lunatic.conversion.FieldSynonymsSerializer;
+
+import java.util.ArrayList;
+
+@JsonSerialize(using = FieldSynonymsSerializer.class)
+public class FieldSynonyms extends ArrayList<FieldSynonym> {}

--- a/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
@@ -8,9 +8,7 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @JsonPropertyOrder({
         "name",

--- a/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.model.flat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
@@ -7,7 +8,9 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @JsonPropertyOrder({
         "name",
@@ -23,14 +26,15 @@ public class SuggesterField {
 
     @JsonProperty(required = true)
     protected String name;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected List<String> rules;
     protected String language;
     protected BigInteger min;
     protected Boolean stemmer;
-    protected List<FieldSynonym> synonyms;
+    protected FieldSynonyms synonyms;
 
     public SuggesterField() {
         this.rules = new ArrayList<>();
-        this.synonyms = new ArrayList<>();
+        this.synonyms = new FieldSynonyms();
     }
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/SuggesterType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/SuggesterType.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.model.flat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class SuggesterType {
     protected List<SuggesterField> fields;
     protected Boolean meloto;
     protected BigInteger max;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected List<String> stopWords;
     protected SuggesterOrder order;
     @JsonProperty(required = true)

--- a/src/test/java/fr/insee/lunatic/conversion/FieldSynonymsSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/FieldSynonymsSerializationTest.java
@@ -1,0 +1,79 @@
+package fr.insee.lunatic.conversion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.*;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
+
+class FieldSynonymsSerializationTest {
+
+    @Test
+    void serializeSynonyms() throws JsonProcessingException, JSONException {
+        //
+        FieldSynonyms fieldSynonyms = new FieldSynonyms();
+        FieldSynonym fieldSynonym = new FieldSynonym();
+        fieldSynonym.setSource("some word");
+        fieldSynonym.setTarget(List.of("synonym 1", "synonym 2"));
+        fieldSynonyms.add(fieldSynonym);
+        //
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule("FieldSynonymsSerializer");
+        module.addSerializer(FieldSynonyms.class, new FieldSynonymsSerializer());
+        mapper.registerModule(module);
+        String result = mapper.writeValueAsString(fieldSynonyms);
+        //
+        String expectedJson = """
+                {
+                  "some word": [
+                    "synonym 1",
+                    "synonym 2"
+                  ]
+                }""";
+        JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void serializeSynonymsFromQuestionnaire() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        SuggesterType suggesterType = new SuggesterType();
+        SuggesterField suggesterField = new SuggesterField();
+        //
+        FieldSynonym fieldSynonym = new FieldSynonym();
+        fieldSynonym.setSource("some word");
+        fieldSynonym.setTarget(List.of("synonym 1", "synonym 2"));
+        //
+        suggesterField.getSynonyms().add(fieldSynonym);
+        suggesterType.getFields().add(suggesterField);
+        questionnaire.getSuggesters().add(suggesterType);
+
+        //
+        JsonSerializer jsonSerializer = new JsonSerializer();
+        String result = jsonSerializer.serialize(questionnaire);
+
+        //
+        String expectedJson = """
+                {
+                  "suggesters": [
+                    {
+                      "fields": [
+                        {
+                          "synonyms": {
+                            "some word": ["synonym 1", "synonym 2"]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }""";
+        JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+    }
+
+}


### PR DESCRIPTION
## Summary

Previously, synonyms in fields of suggesters were (de-)serialized like this :

```json
{
  "synonyms": [
    {
      "source": "some word",
      "target": ["synonym 1", "synonym 2"]
    },
    {
      "source": "some other word",
      "target": ["..."]
    }
  ]
}
```

yet Lunatic expects something like this ("dynamic" keys):

```json
{
  "synonyms": {
    "some word": ["synonym 1", "synonym 2"]
    "some other word": ["..."]
  }
}
```

## Done

- fix `"synonyms"` serialization
- add tests on this
- don't serialize `"rules"` or `"stopWords"` if the list is empty
