### PR TITLE
fix: suggester field rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.2.3-SNAPSHOT</version>
+	<version>3.2.4-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/conversion/FieldRulesSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/FieldRulesSerializer.java
@@ -1,0 +1,54 @@
+package fr.insee.lunatic.conversion;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import fr.insee.lunatic.model.flat.FieldRules;
+
+import java.io.IOException;
+
+/** Temporary custom serializer to mitigate bad pattern in Lunatic modeling.
+ * @see FieldRules */
+public class FieldRulesSerializer extends StdSerializer<FieldRules> {
+
+    @SuppressWarnings("unused") // default constructor is required by jackson
+    public FieldRulesSerializer() {
+        this(null);
+    }
+
+    public FieldRulesSerializer(Class<FieldRules> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(FieldRules fieldRules, JsonGenerator jsonGenerator, SerializerProvider provider)
+            throws IOException {
+        if (fieldRules.getRule() != null && fieldRules.getPatterns() != null) // double check
+            throw new IllegalStateException(FieldRules.ILLEGAL_STATE_MESSAGE);
+
+        if (fieldRules.getRule() != null) {
+            serializeStringRule(fieldRules, jsonGenerator);
+            return;
+        }
+
+        if (fieldRules.getPatterns() != null) {
+            serializePatternsList(fieldRules, jsonGenerator);
+            return;
+        }
+
+        jsonGenerator.writeNull();
+    }
+
+    private void serializeStringRule(FieldRules fieldRules, JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeString(fieldRules.getRule());
+    }
+
+    private void serializePatternsList(FieldRules fieldRules, JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeStartArray();
+        for (String pattern : fieldRules.getPatterns()) {
+            jsonGenerator.writeString(pattern);
+        }
+        jsonGenerator.writeEndArray();
+    }
+
+}

--- a/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
@@ -22,14 +22,6 @@ public class FieldSynonymsSerializer extends StdSerializer<FieldSynonyms> {
     @Override
     public void serialize(FieldSynonyms fieldSynonyms, JsonGenerator jsonGenerator, SerializerProvider provider)
             throws IOException {
-        if (fieldSynonyms.isEmpty()) {
-            jsonGenerator.writeNull();
-            return;
-        }
-        serializeSynonyms(fieldSynonyms, jsonGenerator);
-    }
-
-    private static void serializeSynonyms(FieldSynonyms fieldSynonyms, JsonGenerator jsonGenerator) throws IOException {
         jsonGenerator.writeStartObject();
         for(FieldSynonym fieldSynonym : fieldSynonyms) {
             jsonGenerator.writeArrayFieldStart(fieldSynonym.getSource());

--- a/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/FieldSynonymsSerializer.java
@@ -22,6 +22,14 @@ public class FieldSynonymsSerializer extends StdSerializer<FieldSynonyms> {
     @Override
     public void serialize(FieldSynonyms fieldSynonyms, JsonGenerator jsonGenerator, SerializerProvider provider)
             throws IOException {
+        if (fieldSynonyms.isEmpty()) {
+            jsonGenerator.writeNull();
+            return;
+        }
+        serializeSynonyms(fieldSynonyms, jsonGenerator);
+    }
+
+    private static void serializeSynonyms(FieldSynonyms fieldSynonyms, JsonGenerator jsonGenerator) throws IOException {
         jsonGenerator.writeStartObject();
         for(FieldSynonym fieldSynonym : fieldSynonyms) {
             jsonGenerator.writeArrayFieldStart(fieldSynonym.getSource());

--- a/src/main/java/fr/insee/lunatic/model/flat/FieldRules.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/FieldRules.java
@@ -1,0 +1,43 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import fr.insee.lunatic.conversion.FieldRulesSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Temporary class before Lunatic modeling is changed so to not have a property that can be either string or list. */
+@JsonSerialize(using = FieldRulesSerializer.class)
+public class FieldRules {
+
+    public static final String SOFT_RULE = "soft";
+
+    public static final String ILLEGAL_STATE_MESSAGE = "String and array values are mutually exclusive";
+
+    private String rule;
+    private List<String> patterns;
+
+
+    public String getRule() {
+        return rule;
+    }
+    public void setRule(String rule) {
+        if (patterns != null)
+            throw new IllegalStateException(ILLEGAL_STATE_MESSAGE);
+        if (! SOFT_RULE.equals(rule))
+            throw new IllegalArgumentException("Only '"+SOFT_RULE+"' value is accepted for string rule value.");
+        this.rule = rule;
+    }
+
+    public void addPattern(String pattern) {
+        if (rule != null)
+            throw new IllegalStateException(ILLEGAL_STATE_MESSAGE);
+        if (patterns == null)
+            patterns = new ArrayList<>();
+        patterns.add(pattern);
+    }
+    public List<String> getPatterns() {
+        return patterns;
+    }
+
+}

--- a/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/SuggesterField.java
@@ -7,12 +7,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 
 @JsonPropertyOrder({
         "name",
         "rules",
+        "fieldRules",
         "language",
         "min",
         "stemmer",
@@ -24,15 +23,12 @@ public class SuggesterField {
 
     @JsonProperty(required = true)
     protected String name;
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    protected List<String> rules;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected FieldRules rules;
     protected String language;
     protected BigInteger min;
     protected Boolean stemmer;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected FieldSynonyms synonyms;
 
-    public SuggesterField() {
-        this.rules = new ArrayList<>();
-        this.synonyms = new FieldSynonyms();
-    }
 }

--- a/src/test/java/fr/insee/lunatic/conversion/FieldRulesSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/FieldRulesSerializationTest.java
@@ -1,0 +1,106 @@
+package fr.insee.lunatic.conversion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.FieldRules;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.SuggesterField;
+import fr.insee.lunatic.model.flat.SuggesterType;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+class FieldRulesSerializationTest {
+
+    @Test
+    void serializeRulesProperty_stringCase() throws JsonProcessingException, JSONException {
+        //
+        FieldRules fieldRules = new FieldRules();
+        fieldRules.setRule("soft");
+        //
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule("FieldRulesSerializer");
+        module.addSerializer(FieldRules.class, new FieldRulesSerializer());
+        mapper.registerModule(module);
+        String result = mapper.writeValueAsString(fieldRules);
+        //
+        JSONAssert.assertEquals("\"soft\"", result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void serializeRulesProperty_arrayCase() throws JsonProcessingException, JSONException {
+        //
+        FieldRules fieldRules = new FieldRules();
+        fieldRules.addPattern("[\\w]+");
+        //
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule("FieldRulesSerializer");
+        module.addSerializer(FieldRules.class, new FieldRulesSerializer());
+        mapper.registerModule(module);
+        String result = mapper.writeValueAsString(fieldRules);
+        //
+        JSONAssert.assertEquals("[\"[\\\\w]+\"]", result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void serializeRulesPropertyFromQuestionnaire_stringCase() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        SuggesterType suggesterType = new SuggesterType();
+        SuggesterField suggesterField = new SuggesterField();
+        suggesterField.setRules(new FieldRules());
+        suggesterField.getRules().setRule("soft");
+        suggesterType.getFields().add(suggesterField);
+        questionnaire.getSuggesters().add(suggesterType);
+        //
+        JsonSerializer jsonSerializer = new JsonSerializer();
+        String result = jsonSerializer.serialize(questionnaire);
+        //
+        String expected = """
+                {
+                  "suggesters": [
+                    {
+                      "fields": [
+                        {
+                          "rules": "soft"
+                        }
+                      ]
+                    }
+                  ]
+                }""";
+        JSONAssert.assertEquals(expected, result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void serializeRulesPropertyFromQuestionnaire_arrayCase() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        SuggesterType suggesterType = new SuggesterType();
+        SuggesterField suggesterField = new SuggesterField();
+        suggesterField.setRules(new FieldRules());
+        suggesterField.getRules().addPattern("[\\w]+");
+        suggesterType.getFields().add(suggesterField);
+        questionnaire.getSuggesters().add(suggesterType);
+        //
+        JsonSerializer jsonSerializer = new JsonSerializer();
+        String result = jsonSerializer.serialize(questionnaire);
+        //
+        String expected = """
+                {
+                  "suggesters": [
+                    {
+                      "fields": [
+                        {
+                          "rules": ["[\\\\w]+"]
+                        }
+                      ]
+                    }
+                  ]
+                }""";
+        JSONAssert.assertEquals(expected, result, JSONCompareMode.STRICT);
+    }
+
+}

--- a/src/test/java/fr/insee/lunatic/conversion/FieldSynonymsSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/FieldSynonymsSerializationTest.java
@@ -50,6 +50,7 @@ class FieldSynonymsSerializationTest {
         fieldSynonym.setSource("some word");
         fieldSynonym.setTarget(List.of("synonym 1", "synonym 2"));
         //
+        suggesterField.setSynonyms(new FieldSynonyms());
         suggesterField.getSynonyms().add(fieldSynonym);
         suggesterType.getFields().add(suggesterField);
         questionnaire.getSuggesters().add(suggesterType);


### PR DESCRIPTION
Somewhat linked to:

- InseeFr/Lunatic#784

Patch to Lunatic-Model to make the serialization of the `"rules"` property as either string or array of string possible.
