### PR TITLE
fix: missing label type in pairwise x and y axis iterations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>2.3.4</version>
+	<version>2.3.5</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/resources/xslt/json-cleaner.xsl
+++ b/src/main/resources/xslt/json-cleaner.xsl
@@ -23,7 +23,7 @@
     </xsl:template>
     
     <!-- delete type attribute except when key is linked to the suggesters block or to a label...-->
-    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')] or parent::*[@key=('label','min','max','iterations','conditionFilter','errorMessage','control','expression')])]" mode="clean"/>
+    <xsl:template match="*[@key='type'][not(ancestor::*[@key=('suggesters')] or parent::*[@key=('label','min','max','iterations','conditionFilter','errorMessage','control','expression','xAxisIterations','yAxisIterations')])]" mode="clean"/>
     <!-- delete map useless inside array -->
     <xsl:template match="*[local-name(.)='map'][parent::*[@key=('PREVIOUS','COLLECTED','FORCED','EDITED','INPUTED') and local-name(.)='array'] | parent::*[@key=('values')]]" mode="clean">
         <xsl:apply-templates mode="clean"/>

--- a/src/test/java/fr/insee/lunatic/test/PairwiseTest.java
+++ b/src/test/java/fr/insee/lunatic/test/PairwiseTest.java
@@ -4,6 +4,7 @@ import fr.insee.lunatic.conversion.JSONCleaner;
 import fr.insee.lunatic.conversion.JSONDeserializer;
 import fr.insee.lunatic.conversion.XMLLunaticFlatToJSONLunaticFlatTranslator;
 import fr.insee.lunatic.conversion.XMLLunaticToXMLLunaticFlatTranslator;
+import fr.insee.lunatic.model.flat.LabelType;
 import fr.insee.lunatic.model.flat.PairwiseLinks;
 import fr.insee.lunatic.model.flat.Questionnaire;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test class to see if PairwiseLinks object doesn't break translators */
 class PairwiseTest {
+
+    @Test
+    void convertQuestionnaireWithPairwise_testLabelType() throws Exception {
+        // Given + When
+        XMLLunaticToXMLLunaticFlatTranslator translator1 = new XMLLunaticToXMLLunaticFlatTranslator();
+        XMLLunaticFlatToJSONLunaticFlatTranslator translator2 = new XMLLunaticFlatToJSONLunaticFlatTranslator();
+        JSONCleaner jsonCleaner = new JSONCleaner();
+        String result = jsonCleaner.clean(
+                translator2.translate(
+                        translator1.generate(
+                                this.getClass().getClassLoader().getResourceAsStream(
+                                        "pairwise/label-type-issue/form-hierarchical.xml"))));
+        // Then
+        assertNotNull(result);
+        // Not really clean testing but...
+        String xAxisExpected = "\"xAxisIterations\":{\"value\":\"count(PAIRWISE_SOURCE)\",\"type\":\"VTL\"},";
+        String yAxisExpected = "\"yAxisIterations\":{\"value\":\"count(PAIRWISE_SOURCE)\",\"type\":\"VTL\"},";
+        assertTrue(result.contains(xAxisExpected));
+        assertTrue(result.contains(yAxisExpected));
+    }
 
     @Test
     void deserializeQuestionnaireContainingPairwise_doesContainPairwise() throws JAXBException {

--- a/src/test/resources/pairwise/label-type-issue/form-hierarchical.xml
+++ b/src/test/resources/pairwise/label-type-issue/form-hierarchical.xml
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Questionnaire xmlns="http://xml.insee.fr/schema/applis/lunatic-h"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               id="lo9tkf89"
+               modele="ENOPAIRWISE"
+               enoCoreVersion="${project.version}"
+               missing="false"
+               pagination="none">
+   <label>
+      <value>Eno - Pairwise question</value>
+      <type>VTL|MD</type>
+   </label>
+   <components xsi:type="Loop" componentType="Loop" id="lo9ty2ut" depth="1">
+      <lines>
+         <min>
+            <value>1</value>
+            <type>VTL</type>
+         </min>
+         <max>
+            <value>5</value>
+            <type>VTL</type>
+         </max>
+      </lines>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <bindingDependencies>PAIRWISE_SOURCE</bindingDependencies>
+      <components xsi:type="Sequence" componentType="Sequence" id="lo9tnxzt">
+         <label>
+            <value>"Sequence with loop"</value>
+            <type>VTL|MD</type>
+         </label>
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="lo9tnxzt">
+               <label>
+                  <value>"Sequence with loop"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <components xsi:type="Input"
+                     componentType="Input"
+                     id="lo9twdr9"
+                     maxLength="20"
+                     mandatory="false">
+            <label>
+               <value>"1. " || "Source of the pairwise question"</value>
+               <type>VTL|MD</type>
+            </label>
+            <conditionFilter>
+               <value>true</value>
+               <type>VTL</type>
+            </conditionFilter>
+            <hierarchy>
+               <sequence id="lo9tnxzt">
+                  <label>
+                     <value>"Sequence with loop"</value>
+                     <type>VTL|MD</type>
+                  </label>
+               </sequence>
+            </hierarchy>
+            <bindingDependencies>PAIRWISE_SOURCE</bindingDependencies>
+            <response name="PAIRWISE_SOURCE"/>
+         </components>
+      </components>
+   </components>
+   <components xsi:type="Sequence" componentType="Sequence" id="lo9tqe07">
+      <label>
+         <value>"Pairwise sequence"</value>
+         <type>VTL|MD</type>
+      </label>
+      <conditionFilter>
+         <value>true</value>
+         <type>VTL</type>
+      </conditionFilter>
+      <hierarchy>
+         <sequence id="lo9tqe07">
+            <label>
+               <value>"Pairwise sequence"</value>
+               <type>VTL|MD</type>
+            </label>
+         </sequence>
+      </hierarchy>
+      <components xsi:type="PairwiseLinks"
+                  componentType="PairwiseLinks"
+                  id="lo9tyy1v"
+                  mandatory="false">
+         <conditionFilter>
+            <value>true</value>
+            <type>VTL</type>
+         </conditionFilter>
+         <hierarchy>
+            <sequence id="lo9tqe07">
+               <label>
+                  <value>"Pairwise sequence"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </sequence>
+         </hierarchy>
+         <bindingDependencies>PAIRWISE_QUESTION</bindingDependencies>
+         <xAxisIterations>
+            <value>count(PAIRWISE_SOURCE)</value>
+            <type>VTL</type>
+         </xAxisIterations>
+         <yAxisIterations>
+            <value>count(PAIRWISE_SOURCE)</value>
+            <type>VTL</type>
+         </yAxisIterations>
+         <symLinks name="PAIRWISE_QUESTION">
+            <LINK>
+               <source>1</source>
+               <target>1</target>
+            </LINK>
+            <LINK>
+               <source>2</source>
+               <target>3</target>
+            </LINK>
+            <LINK>
+               <source>3</source>
+               <target>2</target>
+            </LINK>
+            <LINK>
+               <source>4</source>
+               <target>4</target>
+            </LINK>
+            <LINK>
+               <source>5</source>
+               <target>6</target>
+            </LINK>
+            <LINK>
+               <source>6</source>
+               <target>5</target>
+            </LINK>
+            <LINK>
+               <source>7</source>
+               <target>8</target>
+            </LINK>
+            <LINK>
+               <source>8</source>
+               <target>7</target>
+            </LINK>
+            <LINK>
+               <source>9</source>
+               <target>10</target>
+            </LINK>
+            <LINK>
+               <source>10</source>
+               <target>9</target>
+            </LINK>
+            <LINK>
+               <source>11</source>
+               <target>13</target>
+            </LINK>
+            <LINK>
+               <source>12</source>
+               <target>12</target>
+            </LINK>
+            <LINK>
+               <source>13</source>
+               <target>11</target>
+            </LINK>
+            <LINK>
+               <source>14</source>
+               <target>null</target>
+            </LINK>
+            <LINK>
+               <source>15</source>
+               <target>null</target>
+            </LINK>
+            <LINK>
+               <source>16</source>
+               <target>16</target>
+            </LINK>
+            <LINK>
+               <source>17</source>
+               <target>17</target>
+            </LINK>
+            <LINK>
+               <source>18</source>
+               <target>18</target>
+            </LINK>
+         </symLinks>
+         <components xsi:type="Dropdown"
+                     componentType="Dropdown"
+                     id="lo9tyy1v-pairwise-dropdown"
+                     mandatory="false">
+            <label>
+               <value>"2. " || "Pairwise link between " || xAxis || " and " || yAxis</value>
+               <type>VTL|MD</type>
+            </label>
+            <conditionFilter>
+               <value>true</value>
+               <type>VTL</type>
+            </conditionFilter>
+            <bindingDependencies>PAIRWISE_QUESTION</bindingDependencies>
+            <options>
+               <value>linkA</value>
+               <label>
+                  <value>"Link of type A"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>linkB</value>
+               <label>
+                  <value>"Link of type B"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>linkC</value>
+               <label>
+                  <value>"Link of type C"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <options>
+               <value>linkD</value>
+               <label>
+                  <value>"Link of type D"</value>
+                  <type>VTL|MD</type>
+               </label>
+            </options>
+            <response name="PAIRWISE_QUESTION"/>
+         </components>
+      </components>
+   </components>
+   <variables variableType="COLLECTED" xsi:type="VariableTypeArray">
+            <name>PAIRWISE_SOURCE</name>
+            <values>
+               <PREVIOUS xsi:type="PREVIOUSArray">
+                  <PREVIOUS xsi:nil="true"/>
+               </PREVIOUS>
+               <COLLECTED xsi:type="COLLECTEDArray">
+                  <COLLECTED xsi:nil="true"/>
+               </COLLECTED>
+               <FORCED xsi:type="FORCEDArray">
+                  <FORCED xsi:nil="true"/>
+               </FORCED>
+               <EDITED xsi:type="EDITEDArray">
+                  <EDITED xsi:nil="true"/>
+               </EDITED>
+               <INPUTED xsi:type="INPUTEDArray">
+                  <INPUTED xsi:nil="true"/>
+               </INPUTED>
+            </values>
+         </variables>
+   <variables variableType="COLLECTED" xsi:type="VariableTypeArray">
+            <name>PAIRWISE_QUESTION</name>
+            <values>
+               <PREVIOUS xsi:type="PREVIOUSArray">
+                  <PREVIOUS xsi:type="PREVIOUSArray">
+                     <PREVIOUS xsi:nil="true"/>
+                  </PREVIOUS>
+               </PREVIOUS>
+               <COLLECTED xsi:type="COLLECTEDArray">
+                  <COLLECTED xsi:type="COLLECTEDArray">
+                     <COLLECTED xsi:nil="true"/>
+                  </COLLECTED>
+               </COLLECTED>
+               <FORCED xsi:type="FORCEDArray">
+                  <FORCED xsi:type="FORCEDArray">
+                     <FORCED xsi:nil="true"/>
+                  </FORCED>
+               </FORCED>
+               <EDITED xsi:type="EDITEDArray">
+                  <EDITED xsi:type="EDITEDArray">
+                     <EDITED xsi:nil="true"/>
+                  </EDITED>
+               </EDITED>
+               <INPUTED xsi:type="INPUTEDArray">
+                  <INPUTED xsi:type="INPUTEDArray">
+                     <INPUTED xsi:nil="true"/>
+                  </INPUTED>
+               </INPUTED>
+            </values>
+         </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+         <name>xAxis</name>
+         <expression>
+            <value>PAIRWISE_SOURCE</value>
+            <type>VTL</type>
+         </expression>
+         <bindingDependencies>PAIRWISE_SOURCE</bindingDependencies>
+         <shapeFrom>PAIRWISE_SOURCE</shapeFrom>
+      <inFilter>true</inFilter>
+   </variables>
+   <variables variableType="CALCULATED" xsi:type="VariableType">
+         <name>yAxis</name>
+         <expression>
+            <value>PAIRWISE_SOURCE</value>
+            <type>VTL</type>
+         </expression>
+         <bindingDependencies>PAIRWISE_SOURCE</bindingDependencies>
+         <shapeFrom>PAIRWISE_SOURCE</shapeFrom>
+      <inFilter>true</inFilter>
+   </variables>
+   <cleaning/>
+   <resizing>
+      <PAIRWISE_SOURCE>
+         <sizeForLinksVariables>count(PAIRWISE_SOURCE)</sizeForLinksVariables>
+         <sizeForLinksVariables>count(PAIRWISE_SOURCE)</sizeForLinksVariables>
+         <linksVariables>PAIRWISE_QUESTION</linksVariables>
+      </PAIRWISE_SOURCE>
+   </resizing>
+</Questionnaire>


### PR DESCRIPTION
The xslt sheet used in `JSONCleaner` was removing the `"type"` property in `"xAxisIterations"` and `"yAxisIterations"` labels of the pairwise component.