### PR TITLE
fix(suggesters): change version type to integer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.4.0</version>
+	<version>3.4.1</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/conversion/JsonDeserializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/JsonDeserializer.java
@@ -23,7 +23,7 @@ public class JsonDeserializer {
 		logger.info("Deserializing questionnaire from file {}", fileName);
 
 		ObjectMapper mapper = new ObjectMapper();
-		Questionnaire questionnaire = null;
+		Questionnaire questionnaire;
 		try {
 			questionnaire = mapper.readValue(new StreamSource(fileName).getInputStream(), Questionnaire.class);
 		} catch (IOException e) {

--- a/src/main/java/fr/insee/lunatic/model/flat/SuggesterType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/SuggesterType.java
@@ -42,7 +42,7 @@ public class SuggesterType {
     protected SuggesterQueryParser queryParser;
     protected String url;
     @JsonProperty(required = true)
-    protected String version;
+    protected BigInteger version;
 
     public SuggesterType() {
         this.stopWords = new ArrayList<>();

--- a/src/test/java/fr/insee/lunatic/conversion/SuggesterTypeSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/SuggesterTypeSerializationTest.java
@@ -1,0 +1,53 @@
+package fr.insee.lunatic.conversion;
+
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.SuggesterType;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SuggesterTypeSerializationTest {
+
+    private final String jsonSuggesters = """
+            {
+              "id": "questionnaire-id",
+              "componentType": "Questionnaire",
+              "suggesters": [
+                {
+                  "fields": [],
+                  "version": 1
+                }
+              ]
+            }""";
+
+    @Test
+    void serializeSuggesters() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId("questionnaire-id");
+        SuggesterType suggesterType = new SuggesterType();
+        suggesterType.setVersion(BigInteger.ONE);
+        questionnaire.getSuggesters().add(suggesterType);
+        //
+        String result = new JsonSerializer().serialize(questionnaire);
+        //
+        JSONAssert.assertEquals(jsonSuggesters, result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void deserializeSuggesters() throws SerializationException {
+        //
+        Questionnaire questionnaire = new JsonDeserializer().deserialize(
+                new ByteArrayInputStream(jsonSuggesters.getBytes()));
+        //
+        assertEquals(BigInteger.ONE, questionnaire.getSuggesters().getFirst().getVersion());
+    }
+
+}


### PR DESCRIPTION
## Summary

`"version"` property in `"suggesters"` configuration was typed as a String. It should be an integer for Lunatic.

## Done

Changed type to integer. I used java `BigInteger` since it is what's used everywhere in the model, yet I think we should change all these to simple `Integer` someday.