### PR TITLE
refactor: temporary move storeName at ComponentType level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.4.1</version>
+	<version>3.4.2</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
@@ -85,6 +85,11 @@ public abstract class ComponentType {
     protected Boolean mandatory;
     protected String page;
 
+    /** This property should be moved in the Suggester component.
+     * Yet having this property defined here makes Eno suggester specific treatment easier.
+     * To be moved in the Suggester class when the suggester specific treatment is removed in Eno. */
+    protected String storeName;
+
     protected ComponentType() {
         controls = new ArrayList<>();
         declarations = new ArrayList<>();

--- a/src/main/java/fr/insee/lunatic/model/flat/Suggester.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Suggester.java
@@ -11,8 +11,8 @@ import lombok.Setter;
 @Setter
 public class Suggester extends ComponentType implements ComponentSimpleResponseType {
 
-    /** Name of the code list used for auto-completion. */
-    private String storeName;
+    /* Name of the code list used for auto-completion. */
+    //private String storeName;
 
     /** Collected response of the suggester component. */
     @JsonProperty(required = true)


### PR DESCRIPTION
The `storeName` property only concerns the Suggester component.

Yet in Eno, both integrated suggester and  suggester specific treatment exist. In the specific treatment case, it makes it easier to have the store name at ComponentType level for technical reason.
