### PR TITLE
fix: add 'type' property for controls

### DIFF
--- a/src/main/java/fr/insee/lunatic/model/flat/ControlContextType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ControlContextType.java
@@ -1,0 +1,18 @@
+package fr.insee.lunatic.model.flat;
+
+/**
+ * Enum to quality the context in which the control is interpreted.
+ * Determines the behavior of the control in its context.
+ */
+public enum ControlContextType {
+
+    /** Default type. */
+    SIMPLE,
+
+    /** Control at row level of a roster for loop (i.e. dynamic table). */
+    ROW,
+
+    /** Special type of control for roundabouts. */
+    ROUNDABOUT
+
+}

--- a/src/main/java/fr/insee/lunatic/model/flat/ControlCriticalityEnum.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ControlCriticalityEnum.java
@@ -1,9 +1,18 @@
 package fr.insee.lunatic.model.flat;
 
+/**
+ * Enum to qualify the criticality level of a control.
+ * Determines how the control is displayed, and if it is blocking or not.
+ */
 public enum ControlCriticalityEnum {
 
+    /** Informative control. */
     INFO,
+
+    /** Warning control. */
     WARN,
+
+    /** Error control, blocking. */
     ERROR
 
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/ControlType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ControlType.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Control that can be added to response components.
+ */
 @JsonPropertyOrder({
         "id",
         "typeOfControl",
@@ -21,18 +24,32 @@ import java.util.List;
 @Setter
 public class ControlType {
 
+    /** Expression that determines when the control is triggered. */
     @JsonProperty(required = true)
     protected LabelType control;
+
+    /** Message that is displayed to the respondent when the control is triggered. */
     @JsonProperty(required = true)
     protected LabelType errorMessage;
 
+    /** Name of the collected and/or external variables that are required to evaluate the control's expression. */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected List<String> bindingDependencies;
+
+    /** Identifier of the control object. */
     protected String id;
+
+    /** {@link ControlContextType} */
+    protected ControlContextType type;
+
+    /** {@link ControlTypeEnum} */
     protected ControlTypeEnum typeOfControl;
+
+    /** {@link ControlCriticalityEnum} */
     protected ControlCriticalityEnum criticality;
 
     public ControlType() {
+        this.type = ControlContextType.SIMPLE;
         this.bindingDependencies = new ArrayList<>();
     }
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/ControlTypeEnum.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ControlTypeEnum.java
@@ -1,15 +1,15 @@
 package fr.insee.lunatic.model.flat;
 
+/**
+ * Enum to describe the origin of a control.
+ */
 public enum ControlTypeEnum {
 
     /** Control automatically generated from questionnaire's metadata.
      * Example: control that the user input is a number between the min and the max for a number component. */
     FORMAT,
 
-    /** Business-level control defined bt the questionnaire's designer. */
-    CONSISTENCY,
-
-    /** Control to be applied at the line level of a roster for loop (i.e. dynamic table) component. */
-    ROW
+    /** Business-level control defined by the questionnaire's designer. */
+    CONSISTENCY
 
 }


### PR DESCRIPTION
Having both `"typeOfControl"` and `"type"` properties in the `"control"` object is weird, we might do some renaming of these props at some point, yet it's how it's done in Lunatic for now.

https://github.com/InseeFr/Lunatic/blob/825b7096760bf3d866fad7f52508b3e233cca30b/src/type.source.ts#L386