### PR TITLE
feat: condition in multiple choice options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.13.1</version>
+	<version>3.14.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
@@ -42,7 +42,7 @@ public class BodyCell {
     protected String dateFormat;
     protected String unit;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    protected List<Options> options;
+    protected List<Option> options;
     /** For suggester cells: Name of the code list used for auto-completion. */
     private String storeName;
     /** For component cells: collected response of the cell. */

--- a/src/main/java/fr/insee/lunatic/model/flat/CheckboxGroup.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/CheckboxGroup.java
@@ -17,7 +17,7 @@ public class CheckboxGroup extends ComponentType implements ComponentMultipleRes
     protected Orientation orientation;
 
     /** List of the modalities of the checkbox component. */
-    protected List<ResponsesCheckboxGroup> responses;
+    protected List<ResponseCheckboxGroup> responses;
 
     public CheckboxGroup() {
         super();

--- a/src/main/java/fr/insee/lunatic/model/flat/CheckboxOne.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/CheckboxOne.java
@@ -18,7 +18,7 @@ public class CheckboxOne extends ComponentType implements ComponentSimpleRespons
     protected Orientation orientation;
 
     /** List of the modalities of the checkbox component. */
-    protected List<Options> options;
+    protected List<Option> options;
 
     /** {@link ResponseType} */
     @JsonProperty(required = true)

--- a/src/main/java/fr/insee/lunatic/model/flat/Dropdown.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Dropdown.java
@@ -14,7 +14,7 @@ public class Dropdown
     implements ComponentSimpleResponseType
 {
 
-    protected List<Options> options;
+    protected List<Option> options;
 
     @JsonProperty(required = true)
     protected ResponseType response;

--- a/src/main/java/fr/insee/lunatic/model/flat/HeaderType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/HeaderType.java
@@ -21,7 +21,7 @@ public class HeaderType {
     protected String value;
     protected LabelType label;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    protected List<Options> options;
+    protected List<Option> options;
     protected BigInteger colspan;
     protected BigInteger rowspan;
 

--- a/src/main/java/fr/insee/lunatic/model/flat/Option.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Option.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import lombok.Setter;
 
-// TODO: this object class should be renamed to "Option" (singular), the current plural name is misleading.
-
 /**
  * Option / modality of a unique choice component (dropdown, radio, checkbox one).
  */
@@ -16,7 +14,7 @@ import lombok.Setter;
 })
 @Getter
 @Setter
-public class Options {
+public class Option {
 
     /** Response value associated to the modality. */
     @JsonProperty(required = true)
@@ -25,6 +23,10 @@ public class Options {
     /** Displayed label of the modality. */
     @JsonProperty(required = true)
     protected LabelType label;
+
+    /** Filter that determines if the option is displayed or not.
+     * If null, the option is displayed. */
+    protected ConditionFilterType conditionFilter;
 
     /** {@link DetailResponse} */
     protected DetailResponse detail;

--- a/src/main/java/fr/insee/lunatic/model/flat/Option.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Option.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.model.flat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
@@ -26,9 +27,11 @@ public class Option {
 
     /** Filter that determines if the option is displayed or not.
      * If null, the option is displayed. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected ConditionFilterType conditionFilter;
 
     /** {@link DetailResponse} */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected DetailResponse detail;
 
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/Radio.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Radio.java
@@ -18,7 +18,7 @@ public class Radio extends ComponentType implements ComponentSimpleResponseType 
     protected Orientation orientation;
 
     /** List of the modalities of the radio component. */
-    protected List<Options> options;
+    protected List<Option> options;
 
     /** {@link ResponseType} */
     @JsonProperty(required = true)

--- a/src/main/java/fr/insee/lunatic/model/flat/ResponseCheckboxGroup.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ResponseCheckboxGroup.java
@@ -13,16 +13,25 @@ import lombok.Setter;
 })
 @Getter
 @Setter
-public class ResponsesCheckboxGroup {
+public class ResponseCheckboxGroup {
 
+    /** Identifier of the response object. */
+    @JsonProperty(required = true)
+    protected String id;
+
+    /** Displayed label of the modality. */
     @JsonProperty(required = true)
     protected LabelType label;
 
+    /** Filter that determines if the option is displayed or not.
+     * If null, the option is displayed. */
+    protected ConditionFilterType conditionFilter;
+
+    /** Response name of the collected variable that corresponds to the modality. */
     @JsonProperty(required = true)
     protected ResponseType response;
 
+    /** {@link DetailResponse} */
     protected DetailResponse detail;
 
-    @JsonProperty(required = true)
-    protected String id;
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/ResponseCheckboxGroup.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ResponseCheckboxGroup.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.model.flat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
@@ -25,6 +26,7 @@ public class ResponseCheckboxGroup {
 
     /** Filter that determines if the option is displayed or not.
      * If null, the option is displayed. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected ConditionFilterType conditionFilter;
 
     /** Response name of the collected variable that corresponds to the modality. */
@@ -32,6 +34,7 @@ public class ResponseCheckboxGroup {
     protected ResponseType response;
 
     /** {@link DetailResponse} */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     protected DetailResponse detail;
 
 }

--- a/src/test/java/fr/insee/lunatic/conversion/CheckboxGroupSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/CheckboxGroupSerializationTest.java
@@ -18,7 +18,7 @@ class CheckboxGroupSerializationTest {
         CheckboxGroup checkboxGroup = new CheckboxGroup();
         checkboxGroup.setId("foo-id");
         //
-        ResponsesCheckboxGroup response1 = new ResponsesCheckboxGroup();
+        ResponseCheckboxGroup response1 = new ResponseCheckboxGroup();
         response1.setId("response1-id");
         response1.setLabel(new LabelType());
         response1.getLabel().setValue("\"Option A\"");
@@ -27,16 +27,19 @@ class CheckboxGroupSerializationTest {
         response1.getResponse().setName("FOO_A");
         checkboxGroup.getResponses().add(response1);
         //
-        ResponsesCheckboxGroup response2 = new ResponsesCheckboxGroup();
+        ResponseCheckboxGroup response2 = new ResponseCheckboxGroup();
         response2.setId("response2-id");
         response2.setLabel(new LabelType());
         response2.getLabel().setValue("\"Option B\"");
         response2.getLabel().setType(LabelTypeEnum.VTL);
+        response2.setConditionFilter(new ConditionFilterType());
+        response2.getConditionFilter().setValue("<some filter expression>");
+        response2.getConditionFilter().setType(LabelTypeEnum.VTL);
         response2.setResponse(new ResponseType());
         response2.getResponse().setName("FOO_B");
         checkboxGroup.getResponses().add(response2);
         //
-        ResponsesCheckboxGroup responseOther = new ResponsesCheckboxGroup();
+        ResponseCheckboxGroup responseOther = new ResponseCheckboxGroup();
         responseOther.setId("response-other1-id");
         responseOther.setLabel(new LabelType());
         responseOther.getLabel().setValue("\"Other\"");
@@ -51,13 +54,16 @@ class CheckboxGroupSerializationTest {
         responseOther.getDetail().getResponse().setName("FOO_C_DETAIL");
         checkboxGroup.getResponses().add(responseOther);
         //
-        ResponsesCheckboxGroup responseOther2 = new ResponsesCheckboxGroup();
+        ResponseCheckboxGroup responseOther2 = new ResponseCheckboxGroup();
         responseOther2.setId("response-other2-id");
         responseOther2.setLabel(new LabelType());
         responseOther2.getLabel().setValue("\"Another\"");
         responseOther2.getLabel().setType(LabelTypeEnum.VTL);
-        responseOther.setResponse(new ResponseType());
-        responseOther.getResponse().setName("FOO_D");
+        responseOther2.setConditionFilter(new ConditionFilterType());
+        responseOther2.getConditionFilter().setValue("<some filter expression>");
+        responseOther2.getConditionFilter().setType(LabelTypeEnum.VTL);
+        responseOther2.setResponse(new ResponseType());
+        responseOther2.getResponse().setName("FOO_D");
         responseOther2.setDetail(new DetailResponse());
         responseOther2.getDetail().setLabel(new LabelType());
         responseOther2.getDetail().getLabel().setValue("\"Please specify:\"");
@@ -99,6 +105,10 @@ class CheckboxGroupSerializationTest {
                             "value": "\\"Option B\\"",
                             "type": "VTL"
                           },
+                          "conditionFilter": {
+                            "value": "<some filter expression>",
+                            "type": "VTL"
+                          },
                           "response": {
                             "name": "FOO_B"
                           }
@@ -110,7 +120,7 @@ class CheckboxGroupSerializationTest {
                             "type": "VTL"
                           },
                           "response": {
-                            "name": "FOO_D"
+                            "name": "FOO_C"
                           },
                           "detail": {
                             "label": {
@@ -127,6 +137,13 @@ class CheckboxGroupSerializationTest {
                           "label": {
                             "value": "\\"Another\\"",
                             "type": "VTL"
+                          },
+                          "conditionFilter": {
+                            "value": "<some filter expression>",
+                            "type": "VTL"
+                          },
+                          "response": {
+                            "name": "FOO_D"
                           },
                           "detail": {
                             "label": {

--- a/src/test/java/fr/insee/lunatic/conversion/CheckboxOneSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/CheckboxOneSerializationTest.java
@@ -18,21 +18,21 @@ class CheckboxOneSerializationTest {
         CheckboxOne checkboxOne = new CheckboxOne();
         checkboxOne.setId("foo-id");
         //
-        Options option1 = new Options();
+        Option option1 = new Option();
         option1.setLabel(new LabelType());
         option1.setValue("1");
         option1.getLabel().setValue("\"Option A\"");
         option1.getLabel().setType(LabelTypeEnum.VTL);
         checkboxOne.getOptions().add(option1);
         //
-        Options option2 = new Options();
+        Option option2 = new Option();
         option2.setValue("2");
         option2.setLabel(new LabelType());
         option2.getLabel().setValue("\"Option B\"");
         option2.getLabel().setType(LabelTypeEnum.VTL);
         checkboxOne.getOptions().add(option2);
         //
-        Options optionOther = new Options();
+        Option optionOther = new Option();
         optionOther.setValue("3");
         optionOther.setLabel(new LabelType());
         optionOther.getLabel().setValue("\"Other\"");

--- a/src/test/java/fr/insee/lunatic/conversion/RadioSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/RadioSerializationTest.java
@@ -24,21 +24,24 @@ class RadioSerializationTest {
         radio.setId("foo-id");
         radio.setOrientation(Orientation.HORIZONTAL);
         //
-        Options option1 = new Options();
+        Option option1 = new Option();
         option1.setLabel(new LabelType());
         option1.setValue("1");
         option1.getLabel().setValue("\"Option A\"");
         option1.getLabel().setType(LabelTypeEnum.VTL);
         radio.getOptions().add(option1);
         //
-        Options option2 = new Options();
+        Option option2 = new Option();
         option2.setValue("2");
         option2.setLabel(new LabelType());
         option2.getLabel().setValue("\"Option B\"");
         option2.getLabel().setType(LabelTypeEnum.VTL);
+        option2.setConditionFilter(new ConditionFilterType());
+        option2.getConditionFilter().setValue("<some filter expression>");
+        option2.getConditionFilter().setType(LabelTypeEnum.VTL);
         radio.getOptions().add(option2);
         //
-        Options optionOther = new Options();
+        Option optionOther = new Option();
         optionOther.setValue("3");
         optionOther.setLabel(new LabelType());
         optionOther.getLabel().setValue("\"Other\"");
@@ -82,6 +85,10 @@ class RadioSerializationTest {
                           "value": "2",
                           "label": {
                             "value": "\\"Option B\\"",
+                            "type": "VTL"
+                          },
+                          "conditionFilter": {
+                            "value": "<some filter expression>",
                             "type": "VTL"
                           }
                         },

--- a/src/test/java/fr/insee/lunatic/conversion/ResponseCheckboxGroupTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/ResponseCheckboxGroupTest.java
@@ -8,26 +8,26 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-class ResponsesCheckboxGroupTest {
+class ResponseCheckboxGroupTest {
 
     @Test
     void serializeResponseWithDetail() throws JsonProcessingException, JSONException {
         //
-        ResponsesCheckboxGroup responsesCheckboxGroup = new ResponsesCheckboxGroup();
-        responsesCheckboxGroup.setId("kmort6x9-QOP-kmorue9d");
-        responsesCheckboxGroup.setLabel(new LabelType());
-        responsesCheckboxGroup.getLabel().setValue("\"Autre\"");
-        responsesCheckboxGroup.getLabel().setType(LabelTypeEnum.VTL);
-        responsesCheckboxGroup.setResponse(new ResponseType());
-        responsesCheckboxGroup.getResponse().setName("NATIO1N5");
-        responsesCheckboxGroup.setDetail(new DetailResponse());
-        responsesCheckboxGroup.getDetail().setLabel(new LabelType());
-        responsesCheckboxGroup.getDetail().getLabel().setValue("\"Préciser : \"");
-        responsesCheckboxGroup.getDetail().getLabel().setType(LabelTypeEnum.VTL);
-        responsesCheckboxGroup.getDetail().setResponse(new ResponseType());
-        responsesCheckboxGroup.getDetail().getResponse().setName("NATIO1N5DETAIL");
+        ResponseCheckboxGroup responseCheckboxGroup = new ResponseCheckboxGroup();
+        responseCheckboxGroup.setId("kmort6x9-QOP-kmorue9d");
+        responseCheckboxGroup.setLabel(new LabelType());
+        responseCheckboxGroup.getLabel().setValue("\"Autre\"");
+        responseCheckboxGroup.getLabel().setType(LabelTypeEnum.VTL);
+        responseCheckboxGroup.setResponse(new ResponseType());
+        responseCheckboxGroup.getResponse().setName("NATIO1N5");
+        responseCheckboxGroup.setDetail(new DetailResponse());
+        responseCheckboxGroup.getDetail().setLabel(new LabelType());
+        responseCheckboxGroup.getDetail().getLabel().setValue("\"Préciser : \"");
+        responseCheckboxGroup.getDetail().getLabel().setType(LabelTypeEnum.VTL);
+        responseCheckboxGroup.getDetail().setResponse(new ResponseType());
+        responseCheckboxGroup.getDetail().getResponse().setName("NATIO1N5DETAIL");
         //
-        String result = new ObjectMapper().writeValueAsString(responsesCheckboxGroup);
+        String result = new ObjectMapper().writeValueAsString(responseCheckboxGroup);
         //
         String expectedJson = """
                 {


### PR DESCRIPTION
## Summary

- InseeFr/Lunatic#1071

## Done

- feat: add condition filter in option object for unique choice components (radio, checkbox one and dropdown) and in response object for multiple choice component (checkbox group)
- refactor: rename unique choice option and multiple choice response objects (plural was misleading, see below)
- docs: add javadoc in response checkbox group object
- test: fix typo in checkbox group serialization test

⚠️ minor breaking change in Lunatic-Model java API:

- `Options` ➡️ `Option`
- `ResponsesCheckboxGroup` ➡️ `ResponseCheckboxGroup`

(This change has no impact on serialization or deserialization.)
