### PR TITLE
feat: component position property

### DIFF
--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentPosition.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentPosition.java
@@ -1,0 +1,34 @@
+package fr.insee.lunatic.model.flat;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum to define where a component should be displayed in a page.
+ */
+public enum ComponentPosition {
+
+    /** Equivalent to a null value. This value is there to indicate explicitly that the position option is at default
+     * (a null value is implicit). */
+    DEFAULT("default"),
+
+    /** The component should be displayed on the bottom of the page. */
+    BOTTOM("bottom");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    ComponentPosition(String value) {
+        this.value = value;
+    }
+
+    public static ComponentPosition fromValue(String value) {
+        for (ComponentPosition position : ComponentPosition.values()) {
+            if (value.equals(position.value))
+                return position;
+        }
+        throw new IllegalArgumentException(value);
+    }
+
+}

--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
@@ -113,6 +113,9 @@ public abstract class ComponentType {
     protected Boolean mandatory;
     protected String page;
 
+    /** {@link ComponentPosition} */
+    protected ComponentPosition position;
+
     /** This property should be moved in the Suggester component.
      * Yet having this property defined here makes Eno suggester specific treatment easier.
      * To be moved in the Suggester class when the suggester specific treatment is removed in Eno. */

--- a/src/test/java/fr/insee/lunatic/conversion/AccordionSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/AccordionSerializationTest.java
@@ -20,6 +20,7 @@ class AccordionSerializationTest {
               "components": [
                 {
                   "componentType": "Accordion",
+                  "position": "bottom",
                   "items": [
                     {
                       "label": {
@@ -51,6 +52,7 @@ class AccordionSerializationTest {
         //
         Questionnaire questionnaire = new Questionnaire();
         Accordion accordion = new Accordion();
+        accordion.setPosition(ComponentPosition.BOTTOM);
         Accordion.Item item1 = new Accordion.Item();
         item1.setLabel(new LabelType());
         item1.getLabel().setValue("\"Why this question?\"");
@@ -82,6 +84,7 @@ class AccordionSerializationTest {
         //
         Accordion accordion = assertInstanceOf(Accordion.class, questionnaire.getComponents().getFirst());
         assertEquals(ComponentTypeEnum.ACCORDION, accordion.getComponentType());
+        assertEquals(ComponentPosition.BOTTOM, accordion.getPosition());
         //...
     }
 


### PR DESCRIPTION
## Summary

cf.

https://github.com/InseeFr/Lunatic/issues/995#issuecomment-2154361572

## Done

Add a `"position"` property in Lunatic components.

This property can have two values for now: `"default"` and `"bottom"`.

The idea of `"default"` is to be equivalent as `null`, but being explicit (i.e. a null value, or the absence of the position property is implicitely equivalent as the "default" value).
