### PR TITLE
refactor: mark table positioning property as 'for removal'

### DIFF
--- a/docs/fr/components/Table.md
+++ b/docs/fr/components/Table.md
@@ -1,7 +1,6 @@
 ## Le composant `Table`
 
 Il s'agit du composants le plus complexe de Lunatic.
-Comme tous les composants, il a les attributs communs des composants. Il dispose en plus d'un attribut `positioning` pouvant être égale à "HORIZONTAL" ou "VERTICAL".
 
 Il y a deux types de composants `Table` Lunatic :
 
@@ -36,7 +35,6 @@ Dans le dernier cas :
   "id" : "j4nwc63q",
   "componentType" : "Table",
   "mandatory" : false,
-  "positioning" : "HORIZONTAL",
   "label" : "\"label de la question\"",
   "declarations": [...],
   "conditionFilter" : "if ((not(cast(READY,integer) <>  1) )) then \"normal\" else \"hidden\"",

--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
@@ -23,7 +23,6 @@ import java.util.List;
         "goToPage",
         "label",
         "orientation",
-        "positioning",
         "maxLength",
         "min",
         "max",

--- a/src/main/java/fr/insee/lunatic/model/flat/RosterForLoop.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/RosterForLoop.java
@@ -16,6 +16,13 @@ public class RosterForLoop
     protected LinesRoster lines;
     protected List<HeaderType> header;
     protected List<BodyCell> components;
+
+    /**
+     * Metadata on how the table should be displayed.
+     * Value should be one of "HORIZONTAL", "VERTICAL" or "DEFAULT".
+     * @deprecated Unused in Lunatic, to be removed.
+     */
+    @Deprecated(forRemoval = true, since = "3.14.0")
     protected String positioning;
 
     public RosterForLoop() {

--- a/src/main/java/fr/insee/lunatic/model/flat/Table.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Table.java
@@ -20,6 +20,13 @@ public class Table
     protected List<HeaderType> header;
     @JsonProperty("body")
     protected List<BodyLine> bodyLines;
+
+    /**
+     * Metadata on how the table should be displayed.
+     * Value should be one of "HORIZONTAL", "VERTICAL" or "DEFAULT".
+     * @deprecated Unused in Lunatic, to be removed.
+     */
+    @Deprecated(forRemoval = true, since = "3.14.0")
     protected String positioning;
 
     public Table() {


### PR DESCRIPTION
Removed in docs and marked as for removal in the code.