### PR TITLE
fix: add option responses in table cell object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.15.0</version>
+	<version>3.15.1</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/BodyCell.java
@@ -27,6 +27,7 @@ import java.util.List;
         "unit",
         "options",
         "response",
+        "optionResponses",
         "bindingDependencies"
 })
 @Getter
@@ -62,10 +63,15 @@ public class BodyCell {
     protected BigInteger colspan;
     protected BigInteger rowspan;
 
+    /** For suggester cells: option responses. */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected List<Suggester.OptionResponse> optionResponses;
+
     protected String id;
 
     public BodyCell() {
         this.options = new ArrayList<>();
+        this.optionResponses = new ArrayList<>();
     }
 
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
@@ -49,6 +49,7 @@ import java.util.List;
         "components",
         "response",
         "responses",
+        "optionResponses",
         "suggesters",
         "variables",
         "cleaning",


### PR DESCRIPTION
The `"optionResponses` property was missing in the `BodyCell` object.

cf. 

- https://github.com/InseeFr/Eno/issues/1046#issuecomment-2416027625