### PR TITLE
refactor!: remove unused edited forced previous etc values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>3.16.0</version>
+	<version>4.0.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/conversion/variable/CollectedVariableValuesDeserializer.java
+++ b/src/main/java/fr/insee/lunatic/conversion/variable/CollectedVariableValuesDeserializer.java
@@ -17,10 +17,6 @@ import static fr.insee.lunatic.conversion.variable.ValueTypeDeserializer.deseria
 public class CollectedVariableValuesDeserializer extends StdDeserializer<CollectedVariableValues> {
 
     private static final String COLLECTED_KEY = "COLLECTED";
-    private static final String FORCED_KEY = "FORCED";
-    private static final String EDITED_KEY = "EDITED";
-    private static final String PREVIOUS_KEY = "PREVIOUS";
-    private static final String INPUTTED_KEY = "INPUTTED";
 
     public CollectedVariableValuesDeserializer() {
         this(null);
@@ -69,10 +65,6 @@ public class CollectedVariableValuesDeserializer extends StdDeserializer<Collect
     private CollectedVariableValues.Scalar deserializeScalarValues(JsonNode valuesNode) throws JsonParseException {
         CollectedVariableValues.Scalar collectedVariableValues = new CollectedVariableValues.Scalar();
         collectedVariableValues.setCollected(deserializeJsonValue(valuesNode.get(COLLECTED_KEY)));
-        collectedVariableValues.setCollected(deserializeJsonValue(valuesNode.get(FORCED_KEY)));
-        collectedVariableValues.setCollected(deserializeJsonValue(valuesNode.get(EDITED_KEY)));
-        collectedVariableValues.setCollected(deserializeJsonValue(valuesNode.get(PREVIOUS_KEY)));
-        collectedVariableValues.setCollected(deserializeJsonValue(valuesNode.get(INPUTTED_KEY)));
         return collectedVariableValues;
     }
 
@@ -80,18 +72,6 @@ public class CollectedVariableValuesDeserializer extends StdDeserializer<Collect
         CollectedVariableValues.Array collectedVariableValues = new CollectedVariableValues.Array();
         for (JsonNode jsonNode : valuesNode.get(COLLECTED_KEY)) {
             collectedVariableValues.getCollected().add(deserializeJsonValue(jsonNode));
-        }
-        for (JsonNode jsonNode : valuesNode.get(FORCED_KEY)) {
-            collectedVariableValues.getForced().add(deserializeJsonValue(jsonNode));
-        }
-        for (JsonNode jsonNode : valuesNode.get(EDITED_KEY)) {
-            collectedVariableValues.getEdited().add(deserializeJsonValue(jsonNode));
-        }
-        for (JsonNode jsonNode : valuesNode.get(PREVIOUS_KEY)) {
-            collectedVariableValues.getPrevious().add(deserializeJsonValue(jsonNode));
-        }
-        for (JsonNode jsonNode : valuesNode.get(INPUTTED_KEY)) {
-            collectedVariableValues.getInputted().add(deserializeJsonValue(jsonNode));
         }
         return collectedVariableValues;
     }
@@ -106,42 +86,6 @@ public class CollectedVariableValuesDeserializer extends StdDeserializer<Collect
                 valuesList.add(deserializeJsonValue(jsonNode));
             }
             collectedVariableValues.getCollected().add(valuesList);
-        }
-
-        collectedVariableValues.getForced().clear();
-        for (JsonNode jsonArray : valuesNode.get(FORCED_KEY)) {
-            List<ValueType> valuesList = new ArrayList<>();
-            for (JsonNode jsonNode : jsonArray) {
-                valuesList.add(deserializeJsonValue(jsonNode));
-            }
-            collectedVariableValues.getForced().add(valuesList);
-        }
-
-        collectedVariableValues.getEdited().clear();
-        for (JsonNode jsonArray : valuesNode.get(EDITED_KEY)) {
-            List<ValueType> valuesList = new ArrayList<>();
-            for (JsonNode jsonNode : jsonArray) {
-                valuesList.add(deserializeJsonValue(jsonNode));
-            }
-            collectedVariableValues.getEdited().add(valuesList);
-        }
-
-        collectedVariableValues.getPrevious().clear();
-        for (JsonNode jsonArray : valuesNode.get(PREVIOUS_KEY)) {
-            List<ValueType> valuesList = new ArrayList<>();
-            for (JsonNode jsonNode : jsonArray) {
-                valuesList.add(deserializeJsonValue(jsonNode));
-            }
-            collectedVariableValues.getPrevious().add(valuesList);
-        }
-
-        collectedVariableValues.getInputted().clear();
-        for (JsonNode jsonArray : valuesNode.get(INPUTTED_KEY)) {
-            List<ValueType> valuesList = new ArrayList<>();
-            for (JsonNode jsonNode : jsonArray) {
-                valuesList.add(deserializeJsonValue(jsonNode));
-            }
-            collectedVariableValues.getInputted().add(valuesList);
         }
 
         return collectedVariableValues;

--- a/src/main/java/fr/insee/lunatic/model/flat/variable/CollectedVariableValues.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/variable/CollectedVariableValues.java
@@ -11,13 +11,8 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
-@JsonPropertyOrder({
-        "previous",
-        "collected",
-        "forced",
-        "edited",
-        "inputted"
-})
+@JsonPropertyOrder({"collected"})
+
 @JsonDeserialize(using = CollectedVariableValuesDeserializer.class)
 public abstract class CollectedVariableValues {
 
@@ -26,53 +21,25 @@ public abstract class CollectedVariableValues {
     @Getter
     @Setter
     public static class Scalar extends CollectedVariableValues {
-        @JsonInclude @JsonProperty(value = "PREVIOUS")
-        protected ValueType previous;
         @JsonInclude @JsonProperty(value = "COLLECTED")
         protected ValueType collected;
-        @JsonInclude @JsonProperty(value = "FORCED")
-        protected ValueType forced;
-        @JsonInclude @JsonProperty(value = "EDITED")
-        protected ValueType edited;
-        @JsonInclude @JsonProperty(value = "INPUTTED")
-        protected ValueType inputted;
     }
 
     @Getter
     @Setter
     public static class Array extends CollectedVariableValues {
-        @JsonProperty(value = "PREVIOUS")
-        protected List<ValueType> previous = new ArrayList<>();
         @JsonProperty(value = "COLLECTED")
         protected List<ValueType> collected = new ArrayList<>();
-        @JsonProperty(value = "FORCED")
-        protected List<ValueType> forced = new ArrayList<>();
-        @JsonProperty(value = "EDITED")
-        protected List<ValueType> edited = new ArrayList<>();
-        @JsonProperty(value = "INPUTTED")
-        protected List<ValueType> inputted = new ArrayList<>();
     }
 
     @Getter
     @Setter
     public static class DoubleArray extends CollectedVariableValues {
-        @JsonProperty(value = "PREVIOUS")
-        protected List<List<ValueType>> previous;
         @JsonProperty(value = "COLLECTED")
         protected List<List<ValueType>> collected;
-        @JsonProperty(value = "FORCED")
-        protected List<List<ValueType>> forced;
-        @JsonProperty(value = "EDITED")
-        protected List<List<ValueType>> edited;
-        @JsonProperty(value = "INPUTTED")
-        protected List<List<ValueType>> inputted;
 
         public DoubleArray() {
-            previous = newBidimentionalList();
             collected = newBidimentionalList();
-            forced = newBidimentionalList();
-            edited = newBidimentionalList();
-            inputted = newBidimentionalList();
         }
 
         private static List<List<ValueType>> newBidimentionalList() {

--- a/src/test/java/fr/insee/lunatic/conversion/variable/CollectedVariableSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/variable/CollectedVariableSerializationTest.java
@@ -25,13 +25,7 @@ class CollectedVariableSerializationTest {
                 {
                   "variableType": "COLLECTED",
                   "name": "SIMPLE_VAR",
-                  "values": {
-                    "PREVIOUS": null,
-                    "COLLECTED": null,
-                    "FORCED": null,
-                    "EDITED": null,
-                    "INPUTTED": null
-                  }
+                  "values": {"COLLECTED": null}
                 }
               ]
             }""";
@@ -43,13 +37,7 @@ class CollectedVariableSerializationTest {
                 {
                   "variableType": "COLLECTED",
                   "name": "LOOP_VAR",
-                  "values": {
-                    "PREVIOUS": [],
-                    "COLLECTED": [],
-                    "FORCED": [],
-                    "EDITED": [],
-                    "INPUTTED": []
-                  }
+                  "values": {"COLLECTED": []}
                 }
               ]
             }""";
@@ -61,13 +49,7 @@ class CollectedVariableSerializationTest {
                 {
                   "variableType": "COLLECTED",
                   "name": "PAIRWISE_VAR",
-                  "values": {
-                    "PREVIOUS": [[]],
-                    "COLLECTED": [[]],
-                    "FORCED": [[]],
-                    "EDITED": [[]],
-                    "INPUTTED": [[]]
-                  }
+                  "values": {"COLLECTED": [[]]}
                 }
               ]
             }""";


### PR DESCRIPTION
- Suppression des modalités non valorisées de la propriété "values" (EDITED, FORCED, INPUTTED, PREVIOUS) aux emplacements adéquats.
- Ajustement en conséquence des tests liés à ces changements.

PS : je n'ai pas trouvé l'emplacement pour modifier la version.