### PR TITLE
feat: mandatory prop for single response components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
 
-	<version>4.1.1</version>
+	<version>4.2.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ComponentType.java
@@ -111,7 +111,7 @@ public abstract class ComponentType {
     @JsonProperty(required = true)
     protected String id;
     protected ComponentTypeEnum componentType;
-    protected Boolean mandatory;
+
     protected String page;
 
     /** {@link ComponentPosition} */

--- a/src/main/java/fr/insee/lunatic/model/flat/Datepicker.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Datepicker.java
@@ -4,17 +4,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Response component for dates.
+ */
 @Getter
 @Setter
-public class Datepicker
-    extends ComponentType
-    implements ComponentSimpleResponseType
-{
+public class Datepicker extends ComponentType implements ComponentSimpleResponseType {
 
+    public Datepicker() {
+        super();
+        this.componentType = ComponentTypeEnum.DATEPICKER;
+    }
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
+
+    /** Date format. Value must be "YYYY-MM-DD", "YYYY-MM" or "YYYY".
+     * This property should be refactored from String to an enum. */
     @JsonProperty(required = true)
     protected String dateFormat;
+
     @JsonProperty(required = true)
     protected ResponseType response;
+
+    /** Minimum value allowed for the response. */
     protected String min;
+
+    /** Maximum value allowed for the response. */
     protected String max;
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/Dropdown.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Dropdown.java
@@ -7,12 +7,16 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Response component for a unique choice question as a dropdown list.
+ */
 @Getter
 @Setter
-public class Dropdown
-    extends ComponentType
-    implements ComponentSimpleResponseType
-{
+public class Dropdown extends ComponentType implements ComponentSimpleResponseType {
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
 
     protected List<Option> options;
 
@@ -23,4 +27,5 @@ public class Dropdown
         super();
         this.options = new ArrayList<>();
     }
+
 }

--- a/src/main/java/fr/insee/lunatic/model/flat/Duration.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Duration.java
@@ -4,13 +4,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Response component for a duration.
+ */
 @Getter
 @Setter
 public class Duration extends ComponentType implements ComponentSimpleResponseType {
 
     public Duration() {
+        super();
         this.componentType = ComponentTypeEnum.DURATION;
     }
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
 
     @JsonProperty(required = true)
     private DurationFormat format;

--- a/src/main/java/fr/insee/lunatic/model/flat/Input.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Input.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import java.math.BigInteger;
 
 /**
- * Input response component to collect a single line of text.
+ * Response component to collect a single line of text.
  */
 @Getter
 @Setter
@@ -17,6 +17,10 @@ public class Input extends ComponentType implements ComponentSimpleResponseType 
         super();
         this.componentType = ComponentTypeEnum.INPUT;
     }
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
 
     /** Regular expression that the input's content must match. (Unused yet in Lunatic.) */
     protected String format;

--- a/src/main/java/fr/insee/lunatic/model/flat/InputNumber.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/InputNumber.java
@@ -21,6 +21,10 @@ public class InputNumber extends ComponentType implements ComponentSimpleRespons
         this.componentType = ComponentTypeEnum.INPUT_NUMBER;
     }
 
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
+
     /**
      * Wrapper class for the unit property to ensure backward compatibility in serialization/deserialization.
      */

--- a/src/main/java/fr/insee/lunatic/model/flat/Question.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Question.java
@@ -1,5 +1,6 @@
 package fr.insee.lunatic.model.flat;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +15,10 @@ import java.util.List;
 @Getter
 @Setter
 public class Question extends ComponentType {
+
+    /** Indicates if the response to the question is mandatory. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
 
     public Question() {
         this.componentType = ComponentTypeEnum.QUESTION;

--- a/src/main/java/fr/insee/lunatic/model/flat/Radio.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Radio.java
@@ -14,6 +14,10 @@ import java.util.List;
 @Setter
 public class Radio extends ComponentType implements ComponentSimpleResponseType {
 
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
+
     /** Orientation of the radio modalities. */
     protected Orientation orientation;
 

--- a/src/main/java/fr/insee/lunatic/model/flat/Suggester.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Suggester.java
@@ -10,17 +10,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Suggester component.
+ * Suggester response component.
  */
 @Getter
 @Setter
 public class Suggester extends ComponentType implements ComponentSimpleResponseType {
 
     public Suggester() {
+        super();
         this.componentType = ComponentTypeEnum.SUGGESTER;
     }
 
     public record OptionResponse(String name, String attribute) {}
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
 
     /** Collected response of the suggester component. */
     @JsonProperty(required = true)

--- a/src/main/java/fr/insee/lunatic/model/flat/Textarea.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/Textarea.java
@@ -6,13 +6,26 @@ import lombok.Setter;
 
 import java.math.BigInteger;
 
+/**
+ * Response component to collect a block of text.
+ */
 @Getter
 @Setter
-public class Textarea
-    extends ComponentType
-    implements ComponentSimpleResponseType
-{
+public class Textarea extends ComponentType implements ComponentSimpleResponseType {
+
+    public Textarea() {
+        super();
+        this.componentType = ComponentTypeEnum.TEXTAREA;
+    }
+
+    /** Indicates whether the response is mandatory for this component. */
+    @JsonProperty("isMandatory")
+    private Boolean mandatory;
+
     @JsonProperty(required = true)
     protected ResponseType response;
+
+    /** Maximum length of the text response. */
     protected BigInteger maxLength;
+
 }

--- a/src/test/java/fr/insee/lunatic/conversion/DurationSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/DurationSerializationTest.java
@@ -23,6 +23,7 @@ class DurationSerializationTest {
         //
         Duration duration = new Duration();
         duration.setId("duration-id");
+        duration.setMandatory(true);
         duration.setFormat(DurationFormat.YEARS_MONTHS);
         duration.setLabel(new LabelType());
         duration.getLabel().setValue("\"Duration (years/months)\"");
@@ -54,6 +55,7 @@ class DurationSerializationTest {
         //
         Duration duration = new Duration();
         duration.setId("duration-id");
+        duration.setMandatory(false);
         duration.setFormat(DurationFormat.HOURS_MINUTES);
         duration.setLabel(new LabelType());
         duration.getLabel().setValue("\"Duration (hours/minutes)\"");
@@ -84,6 +86,7 @@ class DurationSerializationTest {
         //
         Duration duration = assertInstanceOf(Duration.class, questionnaire.getComponents().getFirst());
         assertEquals("PnYnM", duration.getFormat().value());
+        assertTrue(duration.getMandatory());
     }
 
     @Test
@@ -94,6 +97,7 @@ class DurationSerializationTest {
         Questionnaire questionnaire = new JsonDeserializer().deserialize(new ByteArrayInputStream(jsonInput.getBytes()));
         //
         Duration duration = assertInstanceOf(Duration.class, questionnaire.getComponents().getFirst());
+        assertFalse(duration.getMandatory());
         assertEquals("PTnHnM", duration.getFormat().value());
     }
 

--- a/src/test/java/fr/insee/lunatic/conversion/InputSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/InputSerializationTest.java
@@ -1,0 +1,136 @@
+package fr.insee.lunatic.conversion;
+
+import fr.insee.lunatic.exception.SerializationException;
+import fr.insee.lunatic.model.flat.Input;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.ResponseType;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.ByteArrayInputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InputSerializationTest {
+
+    private final JsonSerializer serializer = new JsonSerializer();
+    private final JsonDeserializer deserializer = new JsonDeserializer();
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void input_withMandatory(Boolean mandatory) throws SerializationException, JSONException {
+        //
+        Input input = new Input();
+        input.setId("input-id");
+        input.setMandatory(mandatory);
+        input.setResponse(new ResponseType());
+        input.getResponse().setName("INPUT_VAR");
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId("questionnaire-id");
+        questionnaire.getComponents().add(input);
+        //
+        String result = serializer.serialize(questionnaire);
+        //
+        String expected = String.format("""
+                {
+                  "id": "questionnaire-id",
+                  "componentType": "Questionnaire",
+                  "components": [
+                    {
+                      "id": "input-id",
+                      "componentType": "Input",
+                      "isMandatory": %s,
+                      "response": {
+                        "name": "INPUT_VAR"
+                      }
+                    }
+                  ]
+                }""", mandatory);
+        JSONAssert.assertEquals(expected, result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void input_withoutMandatory() throws SerializationException, JSONException {
+        //
+        Input input = new Input();
+        input.setId("input-id");
+        input.setResponse(new ResponseType());
+        input.getResponse().setName("INPUT_VAR");
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId("questionnaire-id");
+        questionnaire.getComponents().add(input);
+        //
+        String result = serializer.serialize(questionnaire);
+        //
+        String expected = """
+                {
+                  "id": "questionnaire-id",
+                  "componentType": "Questionnaire",
+                  "components": [
+                    {
+                      "id": "input-id",
+                      "componentType": "Input",
+                      "response": {
+                        "name": "INPUT_VAR"
+                      }
+                    }
+                  ]
+                }""";
+        JSONAssert.assertEquals(expected, result, JSONCompareMode.STRICT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void deserializeInput_withMandatory(Boolean mandatory) throws SerializationException {
+        //
+        String jsonInput = String.format("""
+                {
+                  "id": "questionnaire-id",
+                  "componentType": "Questionnaire",
+                  "components": [
+                    {
+                      "id": "input-id",
+                      "componentType": "Input",
+                      "isMandatory": %s,
+                      "response": {
+                        "name": "INPUT_VAR"
+                      }
+                    }
+                  ]
+                }""", mandatory);
+        //
+        Questionnaire questionnaire = deserializer.deserialize(new ByteArrayInputStream(jsonInput.getBytes()));
+        //
+        Input input = assertInstanceOf(Input.class, questionnaire.getComponents().getFirst());
+        assertEquals(mandatory, input.getMandatory());
+    }
+
+    @Test
+    void deserializeInput_withoutMandatory() throws SerializationException {
+        //
+        String jsonInput = """
+                {
+                  "id": "questionnaire-id",
+                  "componentType": "Questionnaire",
+                  "components": [
+                    {
+                      "id": "input-id",
+                      "componentType": "Input",
+                      "response": {
+                        "name": "INPUT_VAR"
+                      }
+                    }
+                  ]
+                }""";
+        //
+        Questionnaire questionnaire = deserializer.deserialize(new ByteArrayInputStream(jsonInput.getBytes()));
+        //
+        Input input = assertInstanceOf(Input.class, questionnaire.getComponents().getFirst());
+        assertNull(input.getMandatory());
+    }
+
+}

--- a/src/test/resources/duration-hours-minutes.json
+++ b/src/test/resources/duration-hours-minutes.json
@@ -5,6 +5,7 @@
     {
       "id": "duration-id",
       "componentType": "Duration",
+      "isMandatory": false,
       "format": "PTnHnM",
       "label": {
         "value": "\"Duration (hours/minutes)\"",

--- a/src/test/resources/duration-years-months.json
+++ b/src/test/resources/duration-years-months.json
@@ -5,6 +5,7 @@
     {
       "id": "duration-id",
       "componentType": "Duration",
+      "isMandatory": true,
       "format": "PnYnM",
       "label": {
         "value": "\"Duration (years/months)\"",


### PR DESCRIPTION
## Summary

Jusqu'ici, on n'avait pas de concept/fonctionnalité de "réponse obligatoire" dans [Lunatic](https://github.com/InseeFr/Lunatic).

On avait cependant une propriété `"mandatory"` qui traînait dans Luantic-Model (et qu'on doit trouver dans certains source.json de test ou autre).

Désormais, on veut cette fonctionnalité côté Lunatic, pour l'instant pour les **questions à réponse simple** (texte, nombre, date, durée, choix unique).

➡️ propriété `"isMandatory"` pour les composants de question correspondant.

## Done

- suppression de `mandatory` au niveau de `ComponentType` (tous les composants ne sont pas concernés par cette prop, du moins pas pour l'instant).
- ajout d'une property `"isMandatory"` pour le composant `"Question"` (concept de **_question obligatoire_**)
- ajoute d'une property `"isMandatory"` pour les composants : 
  - `Input`
  - `TextArea`
  - `InputNumber`
  - `Datepicker`
  - `Duration`
  - `Radio`
  - `Dropdown`
  - `CheckboxOne`
  - `Suggester`
  - (concept de **_réponse obligatoire_**)

à voir côté Lunatic si on le veut seulement sur la question, seulement sur le composant de réponse, ou les deux.

On fera les changements ici si nécessaire quand ça sera fixé côté Lunatic.

## Example

_Bonus_ : un exemple "storybook-ready" : 

```json
{
  "id": "questionnaire-id",
  "componentType": "Questionnaire",
  "label": {
    "type": "VTL|MD",
    "value": "Questionnaire with mandatory question"
  },
  "pagination": "question",
  "enoCoreVersion": "3.36.1+",
  "lunaticModelVersion": "4.2.0",
  "generatingDate": "14-03-2025 14:57:48",
  "maxPage": "2",
  "components": [
    {
      "id": "sequence-id",
      "componentType": "Sequence",
      "page": "1",
      "label": {
        "type": "VTL",
        "value": "\"Sequence\""
      }
    },
    {
      "id": "question-id",
      "componentType": "Question",
      "page": "2",
      "isMandatory": true,
      "label": {
        "type": "VTL|MD",
        "value": "\"Mandatory question\""
      },
      "components": [
        {
          "id": "input-id",
          "componentType": "Input",
          "page": "2",
          "isMandatory": true,
          "maxLength": 50,
          "response": {
            "name": "Q1"
          }
        }
      ]
    }
  ],
  "variables": [
    {
      "name": "Q1",
      "variableType": "COLLECTED",
      "dimension": 0,
      "values": {
        "COLLECTED": null
      }
    }
  ]
}
```