### PR TITLE
fix(mandatory control): add 'type of control' metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>5.2.0</version>
+	<version>5.2.1-SNAPSHOT</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>5.2.1-SNAPSHOT</version>
+	<version>5.2.1</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/ControlTypeEnum.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/ControlTypeEnum.java
@@ -5,11 +5,16 @@ package fr.insee.lunatic.model.flat;
  */
 public enum ControlTypeEnum {
 
-    /** Control automatically generated from questionnaire's metadata.
+    /** Control automatically generated from questionnaire's metadata in Eno generation.
      * Example: control that the user input is a number between the min and the max for a number component. */
     FORMAT,
 
     /** Business-level control defined by the questionnaire's designer. */
-    CONSISTENCY
+    CONSISTENCY,
+
+    /** Control automatically generated from questionnaire's metadata in Eno generation,
+     * to make a question mandatory.
+     * A "mandatory" control has a specific behavior in Lunatic. */
+    MANDATORY
 
 }


### PR DESCRIPTION
cf.

- InseeFr/Eno#1260

Les contrôles pour les questions obligatoires on un comportement spécifique (notamment dans l'orchestrateur Queen), donc Lunatic a besoin d'une métadonnée pour distinguer ces types de contrôles.
