### PR TITLE
Fix: max length please specify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>5.3.0</version>
+	<version>5.4.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/variable/CollectedVariableType.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/variable/CollectedVariableType.java
@@ -1,7 +1,10 @@
 package fr.insee.lunatic.model.flat.variable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.math.BigInteger;
 
 /**
  * A collected variable is a variable whose value is collected in a response component.
@@ -23,5 +26,9 @@ public class CollectedVariableType extends VariableType {
 
     /** Value field of the collected variable. */
     protected CollectedVariableValues values;
+
+    /** Maximum length allowed for the text value, if applicable. */
+    @JsonProperty("maxLength")
+    protected BigInteger maxLength;
 
 }

--- a/src/test/java/fr/insee/lunatic/conversion/variable/CollectedVariableSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/variable/CollectedVariableSerializationTest.java
@@ -13,6 +13,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -184,6 +185,61 @@ class CollectedVariableSerializationTest {
         assertEquals("PAIRWISE_VAR", collectedVariableType.getName());
         assertEquals(VariableTypeEnum.COLLECTED, collectedVariableType.getVariableType());
         assertInstanceOf(CollectedVariableValues.DoubleArray.class, collectedVariableType.getValues());
+    }
+
+    @Test
+    void serializeVariableWithMaxLength() throws SerializationException, JSONException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        //
+        CollectedVariableType variable = new CollectedVariableType();
+        variable.setName("MAXLEN_VAR");
+        variable.setValues(new CollectedVariableValues.Scalar());
+        variable.setMaxLength(BigInteger.valueOf(4));
+        questionnaire.getVariables().add(variable);
+        //
+        String result = jsonSerializer.serialize(questionnaire);
+        //
+        String expectedJson = """
+        {
+          "componentType": "Questionnaire",
+          "variables": [
+            {
+              "variableType": "COLLECTED",
+              "name": "MAXLEN_VAR",
+              "values": {"COLLECTED": null},
+              "maxLength": 4
+            }
+          ]
+        }""";
+        //
+        JSONAssert.assertEquals(expectedJson, result, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void deserializeVariableWithMaxLength() throws SerializationException {
+        String jsonInput = """
+        {
+          "componentType": "Questionnaire",
+          "variables": [
+            {
+              "variableType": "COLLECTED",
+              "name": "MAXLEN_VAR",
+              "values": {"COLLECTED": null},
+              "maxLength": 4
+            }
+          ]
+        }""";
+
+        Questionnaire questionnaire = jsonDeserializer.deserialize(new ByteArrayInputStream(jsonInput.getBytes()));
+        assertEquals(1, questionnaire.getVariables().size());
+
+        CollectedVariableType variableType = assertInstanceOf(
+                CollectedVariableType.class, questionnaire.getVariables().getFirst());
+        assertEquals("MAXLEN_VAR", variableType.getName());
+        assertEquals(VariableTypeEnum.COLLECTED, variableType.getVariableType());
+        assertInstanceOf(CollectedVariableValues.Scalar.class, variableType.getValues());
+        assertEquals(BigInteger.valueOf(4), variableType.getMaxLength());
     }
 
 }


### PR DESCRIPTION
- Ajout de maxLength pour les variables collectées.
- + Tests.

PS : pour le Lunatic-Model, c'est plutôt un "feat" (d’où le passage de version du 5.3.0 au 5.4.0), mais comme à l'origine c'est un bug dans l'US, alors la branche est un "fix". 