### PR TITLE
refactor(articulation): instantiate items list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>5.8.0</version>
+	<version>5.8.1</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/articulation/Articulation.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/articulation/Articulation.java
@@ -3,18 +3,28 @@ package fr.insee.lunatic.model.flat.articulation;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@Setter
 public class Articulation {
     /**
      * source: id of lunatic roundabout (articulation is based on roundabout)
      */
+    @Getter
+    @Setter
     private String source;
 
     /**
      * list of items to compute table of articulation
      */
-    private List<ArticulationItem> items;
+    @Getter
+    private List<ArticulationItem> items = new ArrayList<>();
+
+    /** @deprecated The list is instantiated when the articulation object is created.
+     * Use the getter method. */
+    @Deprecated(since = "5.8.1")
+    public void setItems(List<ArticulationItem> items) {
+        this.items = items;
+    }
+
 }

--- a/src/test/java/fr/insee/lunatic/conversion/ArticulationSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/ArticulationSerializationTest.java
@@ -37,7 +37,7 @@ class ArticulationSerializationTest {
         sexeItem.setLabel("Sexe");
         sexeItem.setType(LabelTypeEnum.VTL);
         sexeItem.setValue("if SEXE = \"H\" then \"Homme\" else \"Femme\"");
-        articulation.setItems(List.of(prenomItem, sexeItem));
+        articulation.getItems().addAll(List.of(prenomItem, sexeItem));
         questionnaire.setArticulation(articulation);
         //
         String result = new JsonSerializer().serialize(questionnaire);


### PR DESCRIPTION
Partout dans le modèle où on a une liste, elle est initialisée à l'instanciation, je l'ajoute pour la props items de l'articulation pour me simplifier la vie dans Eno.

Quand on supprimera le setter dans une future release, on pourra passer la liste en `final`.
