### PR TITLE
chore: rename cleaning attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>fr.insee.lunatic</groupId>
 	<artifactId>lunatic-model</artifactId>
 	<packaging>jar</packaging>
-	<version>5.15.0</version>
+	<version>5.16.0</version>
 	<name>Lunatic Model</name>
 	<description>Classes and converters for the Lunatic model</description>
 	<url>https://inseefr.github.io/Lunatic-Model/</url>

--- a/src/main/java/fr/insee/lunatic/model/flat/cleaning/CleaningExpression.java
+++ b/src/main/java/fr/insee/lunatic/model/flat/cleaning/CleaningExpression.java
@@ -14,20 +14,21 @@ public class CleaningExpression {
     private String expression;
     private String shapeFrom;
     /**
-     * isAggregatorUsed: determine if expression includes an aggregator (like count, sum,...)
-     * Use-full to improve performance during resizing
+     * shouldCheckAllIterations: determine if expression need to be evaluated during resizing operations
+     *  Use-full to improve performance during resizing
+     *  Used for expression includes an aggregator (like count, sum,...), or for other business case
      */
-    @JsonProperty(value = "isAggregatorUsed")
-    private Boolean isAggregatorUsed;
+    @JsonProperty(value = "shouldCheckDuringResizing")
+    private Boolean shouldCheckDuringResizing;
     /**
      * shouldCheckAllIterations: determine if expression need to be evaluated at each iteration
      */
     @JsonProperty(value = "shouldCheckAllIterations")
     private Boolean shouldCheckAllIterations ;
 
-    public CleaningExpression(String expression, String shapeFrom, boolean isAggregatorUsed) {
+    public CleaningExpression(String expression, String shapeFrom, Boolean shouldCheckDuringResizing) {
         this.expression = expression;
         this.shapeFrom = shapeFrom;
-        this.isAggregatorUsed = isAggregatorUsed;
+        this.shouldCheckDuringResizing = shouldCheckDuringResizing;
     }
 }

--- a/src/test/java/fr/insee/lunatic/conversion/CleaningSerializationTest.java
+++ b/src/test/java/fr/insee/lunatic/conversion/CleaningSerializationTest.java
@@ -23,35 +23,35 @@ class CleaningSerializationTest {
                "cleaning": {
                  "Q1": {
                    "Q21": [
-                     { "expression": "(Q1)", "isAggregatorUsed": false }
+                     { "expression": "(Q1)", "shouldCheckDuringResizing": false }
                    ],
                    "Q22": [
-                     { "expression": "(Q1)", "isAggregatorUsed": false },
+                     { "expression": "(Q1)", "shouldCheckDuringResizing": false },
                      {
                        "expression": "count(Q3_ARRAY)",
                        "shapeFrom": "Q3_ARRAY",
-                       "isAggregatorUsed": true
+                       "shouldCheckDuringResizing": true
                      }
                    ]
                  },
                  "Q2": {
                    "Q22": [
-                     { "expression": "(Q1)", "isAggregatorUsed": false },
+                     { "expression": "(Q1)", "shouldCheckDuringResizing": false },
                      {
                        "expression": "count(Q3_ARRAY)",
                        "shapeFrom": "Q3_ARRAY",
-                       "isAggregatorUsed": true
+                       "shouldCheckDuringResizing": true
                      },
                      {
                        "expression": "count(Q3_ARRAY)",
                        "shapeFrom": "Q3_ARRAY",
-                       "isAggregatorUsed": true,
+                       "shouldCheckDuringResizing": true,
                        "shouldCheckAllIterations": true
                      },
                      {
                        "expression": "count(Q3_ARRAY)",
                        "shapeFrom": "Q3_ARRAY",
-                       "isAggregatorUsed": true,
+                       "shouldCheckDuringResizing": true,
                        "shouldCheckAllIterations": false
                      }
                    ]


### PR DESCRIPTION
Backward compatibility with `isAggregatorUsed` is ensured by Lunatic: see https://github.com/InseeFr/Lunatic/pull/1315